### PR TITLE
로그아웃 및 액세스 토큰 재발급 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,5 +221,7 @@ gradle-app.setting
 *.hprof
 
 application.properties
+.env
+
 
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,windows,macos,visualstudiocode,intellij+all

--- a/.gitignore
+++ b/.gitignore
@@ -222,6 +222,7 @@ gradle-app.setting
 
 application.properties
 .env
+application.yml
 
 
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,windows,macos,visualstudiocode,intellij+all

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,15 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	/* jwt */
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/runrush/be/auth/controller/AuthController.java
+++ b/src/main/java/runrush/be/auth/controller/AuthController.java
@@ -1,0 +1,61 @@
+package runrush.be.auth.controller;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import runrush.be.auth.model.UserPrincipal;
+import runrush.be.auth.service.AuthService;
+
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(@AuthenticationPrincipal UserPrincipal user,
+                                         HttpServletRequest request,
+                                         HttpServletResponse response) {
+        String accessToken = request.getHeader("Authorization");
+
+        authService.logout(accessToken, response);
+
+        SecurityContextHolder.clearContext();
+        return ResponseEntity.ok("로그아웃 되었습니다.");
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(HttpServletRequest request) {
+        String refreshToken = getRefreshTokenFromCookie(request);
+        String accessToken = authService.reissueAccessToken(refreshToken);
+
+        return ResponseEntity.ok(Map.of(
+                "access_token", accessToken,
+                "token_type", "Bearer"
+        ));
+    }
+
+    private String getRefreshTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if(cookies != null) {
+            for( Cookie cookie : cookies ) {
+                if(cookie.getName().equals("refresh_token")) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        throw new RuntimeException("리프레시 토큰이 쿠키에 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/runrush/be/auth/domain/RefreshToken.java
+++ b/src/main/java/runrush/be/auth/domain/RefreshToken.java
@@ -1,0 +1,28 @@
+package runrush.be.auth.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+@Table(name = "refresh_token")
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String token;
+
+    private String userEmail;
+
+    private Instant expiresAt;
+}

--- a/src/main/java/runrush/be/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/runrush/be/auth/jwt/JwtAuthenticationFilter.java
@@ -8,14 +8,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import runrush.be.auth.model.UserPrincipal;
+import runrush.be.user.domain.User;
+import runrush.be.user.repository.UserRepository;
 
 import java.io.IOException;
+import java.util.Collections;
 
 @Component
 @RequiredArgsConstructor
@@ -23,7 +25,7 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final UserDetailsService userDetailsService;
+    private final UserRepository userRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -33,16 +35,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             try {
                 if(jwtTokenProvider.validateToken(token)) {
                     String email = jwtTokenProvider.getEmailFromToken(token);
-                    UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+                    User user = userRepository.findByEmail(email)
+                            .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + email));
+
+                    UserPrincipal userPrincipal = UserPrincipal.create(user, Collections.emptyMap());
 
                     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                            userDetails, null, userDetails.getAuthorities());
+                            userPrincipal, null, userPrincipal.getAuthorities());
                     authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
             } catch (Exception e) {
                 log.error("JWT 인증 처리 중 오류 발생: {}", e.getMessage());
+                SecurityContextHolder.clearContext();
             }
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/runrush/be/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/runrush/be/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package runrush.be.auth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = extractToken(request);
+
+        if(token != null) {
+            try {
+                if(jwtTokenProvider.validateToken(token)) {
+                    String email = jwtTokenProvider.getEmailFromToken(token);
+                    UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities());
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            } catch (Exception e) {
+                log.error("JWT 인증 처리 중 오류 발생: {}", e.getMessage());
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/runrush/be/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/runrush/be/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,93 @@
+package runrush.be.auth.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import runrush.be.user.domain.User;
+import runrush.be.user.repository.UserRepository;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Value("${jwt.access-token.expiration}")
+    private long jwtAccessTokenExpiration;
+
+    @Value("${jwt.refresh-token.expiration}")
+    private long jwtRefreshTokenExpiration;
+
+    private final UserRepository userRepository;
+
+    private SecretKey getSigningKey() {
+        byte[] keyBytes = jwtSecret.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String generateAccessToken(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: "+ email));
+
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtAccessTokenExpiration);
+
+        return Jwts.builder()
+                .subject(email)
+                .claim("userId", user.getId())
+                .claim("name", user.getName())
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    public String generateRefreshToken(String email) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtRefreshTokenExpiration);
+
+        return Jwts.builder()
+                .subject(email)
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public String getEmailFromToken(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    public Long getUserIdFromToken(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get("userId", Long.class);
+    }
+
+    public boolean validateToken(String token) {
+        if (token == null || !token.contains(".")) {
+            return false;
+        }
+
+        Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token);
+        return true;
+    }
+}

--- a/src/main/java/runrush/be/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/runrush/be/auth/jwt/JwtTokenProvider.java
@@ -11,6 +11,7 @@ import runrush.be.user.repository.UserRepository;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Date;
 
 @Component
@@ -77,6 +78,11 @@ public class JwtTokenProvider {
     public Long getUserIdFromToken(String token) {
         Claims claims = parseClaims(token);
         return claims.get("userId", Long.class);
+    }
+
+    public Instant getJwtExpiration(String token) {
+        Claims claims = parseClaims(token);
+        return claims.getExpiration().toInstant();
     }
 
     public boolean validateToken(String token) {

--- a/src/main/java/runrush/be/auth/model/UserPrincipal.java
+++ b/src/main/java/runrush/be/auth/model/UserPrincipal.java
@@ -1,0 +1,72 @@
+package runrush.be.auth.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import runrush.be.user.domain.User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class UserPrincipal implements OAuth2User, UserDetails {
+    private Long id;
+    private String email;
+    private String password;
+    private Collection<? extends GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
+
+    public static UserPrincipal create(User user, Map<String, Object> attributes) {
+        List<GrantedAuthority> authorities = Collections
+                .singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+
+        return UserPrincipal.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .password("")
+                .authorities(authorities)
+                .attributes(attributes)
+                .build();
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getName() {
+        return id.toString();
+    }
+}

--- a/src/main/java/runrush/be/auth/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/runrush/be/auth/oauth2/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,71 @@
+package runrush.be.auth.oauth2;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import runrush.be.auth.domain.RefreshToken;
+import runrush.be.auth.jwt.JwtTokenProvider;
+import runrush.be.auth.model.UserPrincipal;
+import runrush.be.auth.repository.RefreshTokenRepository;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        log.info("OAuth2 로그인 성공");
+
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+        String email = userPrincipal.getEmail();
+
+        String accessToken = jwtTokenProvider.generateAccessToken(email);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(email);
+        Instant jwtExpiration = jwtTokenProvider.getJwtExpiration(refreshToken);
+        long secondsUntilExpiration = jwtExpiration.getEpochSecond() - Instant.now().getEpochSecond();
+
+        refreshTokenRepository.deleteByUserEmail(email);
+        RefreshToken rToken = RefreshToken.builder()
+                .userEmail(email)
+                .token(refreshToken)
+                .expiresAt(jwtExpiration)
+                .build();
+        refreshTokenRepository.save(rToken);
+
+        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(false); // 로컬
+        refreshTokenCookie.setMaxAge((int) secondsUntilExpiration);
+        response.addCookie(refreshTokenCookie);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("accessToken", accessToken);
+        responseBody.put("tokenType", "Bearer");
+        responseBody.put("status", "success");
+
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody));
+        log.info("OAuth2 로그인 성공 처리 완료");
+    }
+}

--- a/src/main/java/runrush/be/auth/oauth2/dto/KakaoOAuth2UserInfo.java
+++ b/src/main/java/runrush/be/auth/oauth2/dto/KakaoOAuth2UserInfo.java
@@ -1,0 +1,35 @@
+package runrush.be.auth.oauth2.dto;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
+    private Map<String, Object> attributes;
+    private Map<String, Object> kakaoAccount;
+    private Map<String, Object> profile;
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        this.profile = (Map<String, Object>) attributes.get("kakao_profile");
+    }
+
+    @Override
+    public String getId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getName() {
+        return (String) profile.get("nickname");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) kakaoAccount.get("email");
+    }
+
+    @Override
+    public String getImage() {
+        return (String) profile.get("profile_image_url");
+    }
+}

--- a/src/main/java/runrush/be/auth/oauth2/dto/KakaoOAuth2UserInfo.java
+++ b/src/main/java/runrush/be/auth/oauth2/dto/KakaoOAuth2UserInfo.java
@@ -4,13 +4,18 @@ import java.util.Map;
 
 public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
     private Map<String, Object> attributes;
+    private Map<String, Object> properties;
     private Map<String, Object> kakaoAccount;
     private Map<String, Object> profile;
 
     public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
         this.attributes = attributes;
+        this.properties = (Map<String, Object>) attributes.get("properties");
         this.kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-        this.profile = (Map<String, Object>) attributes.get("kakao_profile");
+
+        if (this.kakaoAccount != null && this.kakaoAccount.containsKey("profile")) {
+            this.profile = (Map<String, Object>) this.kakaoAccount.get("profile");
+        }
     }
 
     @Override

--- a/src/main/java/runrush/be/auth/oauth2/dto/OAuth2UserInfo.java
+++ b/src/main/java/runrush/be/auth/oauth2/dto/OAuth2UserInfo.java
@@ -1,0 +1,8 @@
+package runrush.be.auth.oauth2.dto;
+
+public interface OAuth2UserInfo{
+    String getId();
+    String getName();
+    String getEmail();
+    String getImage();
+}

--- a/src/main/java/runrush/be/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/runrush/be/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package runrush.be.auth.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import runrush.be.auth.domain.RefreshToken;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByUserEmail(String email);
+    void deleteByUserEmail(String email);
+}

--- a/src/main/java/runrush/be/auth/service/AuthService.java
+++ b/src/main/java/runrush/be/auth/service/AuthService.java
@@ -1,0 +1,40 @@
+package runrush.be.auth.service;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import runrush.be.auth.jwt.JwtTokenProvider;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final RefreshTokenService refreshTokenService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public void logout(String accessToken, HttpServletResponse response) {
+        if (accessToken == null || !accessToken.startsWith("Bearer ")) {
+            throw new IllegalArgumentException("유효한 토큰 형식이 아닙니다.");
+        }
+
+        String token = accessToken.substring(7);
+
+        if (!jwtTokenProvider.validateToken(token)) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
+        String email = jwtTokenProvider.getEmailFromToken(token);
+
+        refreshTokenService.deleteRefreshToken(email);
+
+        Cookie cookie = new Cookie("refresh_token", "");
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        response.addCookie(cookie);
+    }
+
+    public String reissueAccessToken(String refreshToken) {
+        return refreshTokenService.renewAccessToken(refreshToken);
+    }
+}

--- a/src/main/java/runrush/be/auth/service/RefreshTokenService.java
+++ b/src/main/java/runrush/be/auth/service/RefreshTokenService.java
@@ -1,0 +1,53 @@
+package runrush.be.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import runrush.be.auth.domain.RefreshToken;
+import runrush.be.auth.jwt.JwtTokenProvider;
+import runrush.be.auth.repository.RefreshTokenRepository;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    @Value("${jwt.refresh-token.expiration}")
+    private long jwtRefreshTokenExpiration;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public Optional<RefreshToken> findByToken(String token) {
+        return refreshTokenRepository.findByToken(token);
+    }
+
+    private void verifyExpiration(RefreshToken token) {
+        if (token.getExpiresAt().compareTo(Instant.now()) < 0) {
+            refreshTokenRepository.delete(token);
+            throw new RuntimeException("리프레시 토큰이 만료되었습니다. 다시 로그인해주세요");
+        }
+
+        if(!jwtTokenProvider.validateToken(token.getToken())) {
+            refreshTokenRepository.delete(token);
+            throw new RuntimeException("리프레시 토큰이 유효하지 않습니다. 다시 로그인해주세요.");
+        }
+    }
+
+    public String renewAccessToken(String token) {
+        RefreshToken refreshToken = findByToken(token)
+                .orElseThrow(() -> new RuntimeException("리프레시 토큰이 존재하지 않습니다."));
+
+        verifyExpiration(refreshToken);
+
+        return jwtTokenProvider.generateAccessToken(refreshToken.getUserEmail());
+    }
+
+    @Transactional
+    public void deleteRefreshToken(String userEmail) {
+        refreshTokenRepository.deleteByUserEmail(userEmail);
+    }
+}

--- a/src/main/java/runrush/be/auth/service/RefreshTokenService.java
+++ b/src/main/java/runrush/be/auth/service/RefreshTokenService.java
@@ -1,7 +1,6 @@
 package runrush.be.auth.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import runrush.be.auth.domain.RefreshToken;
@@ -15,26 +14,11 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class RefreshTokenService {
 
-    @Value("${jwt.refresh-token.expiration}")
-    private long jwtRefreshTokenExpiration;
-
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
     public Optional<RefreshToken> findByToken(String token) {
         return refreshTokenRepository.findByToken(token);
-    }
-
-    private void verifyExpiration(RefreshToken token) {
-        if (token.getExpiresAt().compareTo(Instant.now()) < 0) {
-            refreshTokenRepository.delete(token);
-            throw new RuntimeException("리프레시 토큰이 만료되었습니다. 다시 로그인해주세요");
-        }
-
-        if(!jwtTokenProvider.validateToken(token.getToken())) {
-            refreshTokenRepository.delete(token);
-            throw new RuntimeException("리프레시 토큰이 유효하지 않습니다. 다시 로그인해주세요.");
-        }
     }
 
     public String renewAccessToken(String token) {
@@ -47,7 +31,32 @@ public class RefreshTokenService {
     }
 
     @Transactional
+    public void renewRefreshToken(String email, String token, Instant expiresAt) {
+        refreshTokenRepository.deleteByUserEmail(email);
+
+        RefreshToken refreshToken = RefreshToken.builder()
+                .userEmail(email)
+                .token(token)
+                .expiresAt(expiresAt)
+                .build();
+
+        refreshTokenRepository.save(refreshToken);
+    }
+
+    @Transactional
     public void deleteRefreshToken(String userEmail) {
         refreshTokenRepository.deleteByUserEmail(userEmail);
+    }
+
+    private void verifyExpiration(RefreshToken token) {
+        if (token.getExpiresAt().compareTo(Instant.now()) < 0) {
+            refreshTokenRepository.delete(token);
+            throw new RuntimeException("리프레시 토큰이 만료되었습니다. 다시 로그인해주세요");
+        }
+
+        if(!jwtTokenProvider.validateToken(token.getToken())) {
+            refreshTokenRepository.delete(token);
+            throw new RuntimeException("리프레시 토큰이 유효하지 않습니다. 다시 로그인해주세요.");
+        }
     }
 }

--- a/src/main/java/runrush/be/config/SecurityConfig.java
+++ b/src/main/java/runrush/be/config/SecurityConfig.java
@@ -1,0 +1,49 @@
+package runrush.be.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import runrush.be.auth.jwt.JwtAuthenticationFilter;
+import runrush.be.auth.oauth2.OAuth2LoginSuccessHandler;
+import runrush.be.user.service.CustomOAuth2UserService;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/oauth2/**", "/login/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService)
+                        )
+                        .successHandler(oAuth2LoginSuccessHandler)
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/runrush/be/user/domain/Level.java
+++ b/src/main/java/runrush/be/user/domain/Level.java
@@ -1,0 +1,20 @@
+package runrush.be.user.domain;
+
+public enum Level {
+    BEGINNER(1, "초보 러너", 0, 100),
+    INTERMEDIATE(2, "열정 러너", 100, 300),
+    ADVANCED(3, "숙련 러너", 300, 600),
+    EXPERT(4, "엘리트 러너", 600, 1000);
+
+    private final int value;
+    private final String title;
+    private final int minExp;
+    private final int maxExp;
+
+    Level(int value, String title, int minExp, int maxExp) {
+        this.value = value;
+        this.title = title;
+        this.minExp = minExp;
+        this.maxExp = maxExp;
+    }
+}

--- a/src/main/java/runrush/be/user/domain/User.java
+++ b/src/main/java/runrush/be/user/domain/User.java
@@ -1,0 +1,42 @@
+package runrush.be.user.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "user")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "kakao_id")
+    private String kakaoId;
+
+    private String email;
+
+    private String name;
+
+    @Column(name = "profile_image")
+    private String profileImage;
+
+    @Enumerated(EnumType.STRING)
+    private Level level;
+
+    private int experiencePoints;
+
+    @Builder
+    public User(String kakaoId, String email, String name, String profileImage) {
+        this.kakaoId = kakaoId;
+        this.email = email;
+        this.name = name;
+        this.profileImage = profileImage;
+        this.level = Level.BEGINNER;
+        this.experiencePoints = 0;
+    }
+}

--- a/src/main/java/runrush/be/user/repository/UserRepository.java
+++ b/src/main/java/runrush/be/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package runrush.be.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import runrush.be.user.domain.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByKakaoId(String kakaoId);
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/runrush/be/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/runrush/be/user/service/CustomOAuth2UserService.java
@@ -3,19 +3,17 @@ package runrush.be.user.service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import runrush.be.auth.model.UserPrincipal;
 import runrush.be.auth.oauth2.dto.KakaoOAuth2UserInfo;
 import runrush.be.user.domain.User;
 import runrush.be.user.repository.UserRepository;
 
-import java.util.Collections;
 import java.util.Map;
 
 @Service
@@ -54,10 +52,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         log.info("카카오 로그인 성공: 사용자 ID = {}, 이메일 = {}", user.getId(), email);
 
-        return new DefaultOAuth2User(
-                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
-                attributes,
-                "id"
-        );
+        return UserPrincipal.create(user, attributes);
     }
 }

--- a/src/main/java/runrush/be/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/runrush/be/user/service/CustomOAuth2UserService.java
@@ -1,0 +1,63 @@
+package runrush.be.user.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import runrush.be.auth.oauth2.dto.KakaoOAuth2UserInfo;
+import runrush.be.user.domain.User;
+import runrush.be.user.repository.UserRepository;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        Map<String, Object> attributes = super.loadUser(userRequest).getAttributes();
+        log.debug("응답 구조: {}", attributes);
+
+        KakaoOAuth2UserInfo userInfo = new KakaoOAuth2UserInfo(attributes);
+
+        String email = userInfo.getEmail();
+        if (email == null || email.isEmpty()) {
+            throw new OAuth2AuthenticationException(new OAuth2Error(
+                    "이메일 정보 제공에 동의해주세요."
+            ));
+        }
+
+        User user = userRepository.findByKakaoId(userInfo.getId())
+                .orElseGet(() -> {
+                    User newUser = User.builder()
+                            .kakaoId(userInfo.getId())
+                            .email(userInfo.getEmail())
+                            .name(userInfo.getName())
+                            .profileImage(userInfo.getImage())
+                            .build();
+                    return userRepository.save(newUser);
+                });
+
+        log.info("카카오 로그인 성공: 사용자 ID = {}, 이메일 = {}", user.getId(), email);
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+                attributes,
+                "id"
+        );
+    }
+}

--- a/src/main/java/runrush/be/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/runrush/be/user/service/CustomOAuth2UserService.java
@@ -28,7 +28,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
         Map<String, Object> attributes = super.loadUser(userRequest).getAttributes();
-        log.debug("응답 구조: {}", attributes);
+        log.info("응답 구조: {}", attributes);
 
         KakaoOAuth2UserInfo userInfo = new KakaoOAuth2UserInfo(attributes);
 


### PR DESCRIPTION
## 🔐 로그아웃 및 액세스 토큰 재발급 API 구현

### ✨ 작업 내용
- JWT 기반 로그아웃 및 액세스 토큰 재발급 API를 구현했습니다.
- OAuth2 로그인 시 사용자 정보를 저장하고, JWT 토큰을 생성합니다.
- 요청마다 JWT를 검사해 인증 처리를 수행합니다.

### 🎯 관련 이슈
- #1 