### PR TITLE
OAuth2 로그인 성공 리다이렉트 처리 및 JWT 인증/재발급/로그아웃 기능 구현

### DIFF
--- a/src/main/java/runrush/be/auth/controller/AuthController.java
+++ b/src/main/java/runrush/be/auth/controller/AuthController.java
@@ -6,12 +6,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import runrush.be.auth.model.UserPrincipal;
 import runrush.be.auth.service.AuthService;
 
 import java.util.Map;
@@ -25,13 +23,12 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(@AuthenticationPrincipal UserPrincipal user,
+    public ResponseEntity<String> logout(
                                          HttpServletRequest request,
                                          HttpServletResponse response) {
         String accessToken = request.getHeader("Authorization");
 
         authService.logout(accessToken, response);
-
         SecurityContextHolder.clearContext();
         return ResponseEntity.ok("로그아웃 되었습니다.");
     }

--- a/src/main/java/runrush/be/auth/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/runrush/be/auth/oauth2/OAuth2LoginSuccessHandler.java
@@ -1,33 +1,29 @@
 package runrush.be.auth.oauth2;
 
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import runrush.be.auth.jwt.JwtTokenProvider;
 import runrush.be.auth.model.UserPrincipal;
-import runrush.be.auth.service.RefreshTokenService;
+import runrush.be.auth.service.AuthService;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
-    private final JwtTokenProvider jwtTokenProvider;
-    private final RefreshTokenService refreshTokenService;
-    private final ObjectMapper objectMapper;
+    private final AuthService authService;
+
+    @Value("${app.frontend.callback-url}")
+    private String callbackUrl;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -36,29 +32,12 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
         String email = userPrincipal.getEmail();
 
-        String accessToken = jwtTokenProvider.generateAccessToken(email);
-        String refreshToken = jwtTokenProvider.generateRefreshToken(email);
-        Instant jwtExpiration = jwtTokenProvider.getJwtExpiration(refreshToken);
-        long secondsUntilExpiration = jwtExpiration.getEpochSecond() - Instant.now().getEpochSecond();
+        authService.setRefreshTokenCookie(email, response);
+        String accessToken = authService.generateAccessToken(email);
 
-        refreshTokenService.renewRefreshToken(email, refreshToken, jwtExpiration);
+        String redirectUrl = callbackUrl + "?accessToken=" + accessToken;
 
-        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
-        refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setSecure(false); // 로컬
-        refreshTokenCookie.setMaxAge((int) secondsUntilExpiration);
-        response.addCookie(refreshTokenCookie);
-
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-
-        Map<String, Object> responseBody = new HashMap<>();
-        responseBody.put("accessToken", accessToken);
-        responseBody.put("tokenType", "Bearer");
-        responseBody.put("status", "success");
-
-        response.getWriter().write(objectMapper.writeValueAsString(responseBody));
+        response.sendRedirect(redirectUrl);
         log.info("OAuth2 로그인 성공 처리 완료");
     }
 }

--- a/src/main/java/runrush/be/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/runrush/be/auth/oauth2/service/CustomOAuth2UserService.java
@@ -1,4 +1,4 @@
-package runrush.be.user.service;
+package runrush.be.auth.oauth2.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/runrush/be/auth/service/RefreshTokenService.java
+++ b/src/main/java/runrush/be/auth/service/RefreshTokenService.java
@@ -21,6 +21,7 @@ public class RefreshTokenService {
         return refreshTokenRepository.findByToken(token);
     }
 
+    @Transactional
     public String renewAccessToken(String token) {
         RefreshToken refreshToken = findByToken(token)
                 .orElseThrow(() -> new RuntimeException("리프레시 토큰이 존재하지 않습니다."));

--- a/src/main/java/runrush/be/config/SecurityConfig.java
+++ b/src/main/java/runrush/be/config/SecurityConfig.java
@@ -10,9 +10,14 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import runrush.be.auth.jwt.JwtAuthenticationFilter;
 import runrush.be.auth.oauth2.OAuth2LoginSuccessHandler;
-import runrush.be.user.service.CustomOAuth2UserService;
+import runrush.be.auth.oauth2.service.CustomOAuth2UserService;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -46,4 +51,19 @@ public class SecurityConfig {
 
         return http.build();
     }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedOrigins(List.of("http://localhost:5173"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("Authorization")); // 필요시 추가
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
 }

--- a/src/main/java/runrush/be/user/controller/UserController.java
+++ b/src/main/java/runrush/be/user/controller/UserController.java
@@ -1,0 +1,30 @@
+package runrush.be.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import runrush.be.auth.model.UserPrincipal;
+import runrush.be.user.domain.User;
+import runrush.be.user.dto.UserInfoResponse;
+import runrush.be.user.service.UserService;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @GetMapping
+    public ResponseEntity<UserInfoResponse> getUserInfo(@AuthenticationPrincipal UserPrincipal user) {
+        if(user == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        User userByEmail = userService.findUserByEmail(user.getEmail());
+        UserInfoResponse userInfoResponse = UserInfoResponse.fromEntity(userByEmail);
+        return ResponseEntity.ok(userInfoResponse);
+    }
+}

--- a/src/main/java/runrush/be/user/dto/UserInfoResponse.java
+++ b/src/main/java/runrush/be/user/dto/UserInfoResponse.java
@@ -1,0 +1,22 @@
+package runrush.be.user.dto;
+
+import runrush.be.user.domain.Level;
+import runrush.be.user.domain.User;
+
+public record UserInfoResponse(
+        String email,
+        String name,
+        String profileImage,
+        Level level,
+        int experiencePoints
+) {
+    public static UserInfoResponse fromEntity(User user) {
+        return new UserInfoResponse(
+                user.getEmail(),
+                user.getName(),
+                user.getProfileImage(),
+                user.getLevel(),
+                user.getExperiencePoints()
+        );
+    }
+}

--- a/src/main/java/runrush/be/user/service/UserService.java
+++ b/src/main/java/runrush/be/user/service/UserService.java
@@ -1,0 +1,17 @@
+package runrush.be.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import runrush.be.user.domain.User;
+import runrush.be.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public User findUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+    }
+}


### PR DESCRIPTION
### ✨ 작업 내용
- OAuth2 로그인 성공 시 accessToken을 쿼리로 프론트에 전달하도록 리다이렉트 방식 변경
- AuthService에서 리프레시 토큰 쿠키 설정 및 accessToken 생성 기능 추가
- AuthController에 logout, reissue API 추가로 인증 흐름 완성
- RefreshTokenService 분리 및 재사용 가능한 구조로 리팩토링
- JwtAuthenticationFilter에서 UserPrincipal 직접 생성으로 인증 객체 일관화
- SecurityConfig에 명시적 CORS 설정 추가 (localhost:5173 허용)

- `UserInfoResponse` DTO 구현으로 사용자 정보 응답 구조 정의
- `UserService`에 이메일 기반 사용자 조회 기능 추가
- `UserController`의 `/user` GET API 구현으로 인증된 사용자 정보 조회 기능 제공


### 🎯 관련 이슈
- #3 