### PR TITLE
러닝 기록 등록 및 조회 기능 구현

### DIFF
--- a/src/main/java/runrush/be/BeApplication.java
+++ b/src/main/java/runrush/be/BeApplication.java
@@ -2,8 +2,10 @@ package runrush.be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/runrush/be/runningrecord/controller/RunningRecordController.java
+++ b/src/main/java/runrush/be/runningrecord/controller/RunningRecordController.java
@@ -1,0 +1,39 @@
+package runrush.be.runningrecord.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import runrush.be.runningrecord.dto.RunningRecordListResponse;
+import runrush.be.runningrecord.dto.RunningRecordRequest;
+import runrush.be.runningrecord.dto.RunningRecordResponse;
+import runrush.be.runningrecord.service.RunningRecordService;
+import runrush.be.user.domain.User;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/running-record")
+@RequiredArgsConstructor
+public class RunningRecordController {
+    private final RunningRecordService runningRecordService;
+
+    @PostMapping
+    public ResponseEntity<Void> createRunningRecord(@AuthenticationPrincipal User user,
+                                                             @RequestBody RunningRecordRequest request) {
+        runningRecordService.saveRunningRecord(request, user.getEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<RunningRecordListResponse>> getRunningRecords(@AuthenticationPrincipal User user) {
+        List<RunningRecordListResponse> runningRecords = runningRecordService.getRunningRecords(user.getEmail());
+        return ResponseEntity.ok(runningRecords);
+    }
+
+    @GetMapping("/{recordId}")
+    public ResponseEntity<RunningRecordResponse> getRunningRecord(@PathVariable Long recordId) {
+        RunningRecordResponse runningRecord = runningRecordService.getRunningRecord(recordId);
+        return ResponseEntity.ok(runningRecord);
+    }
+}

--- a/src/main/java/runrush/be/runningrecord/domain/RunningRecord.java
+++ b/src/main/java/runrush/be/runningrecord/domain/RunningRecord.java
@@ -1,0 +1,79 @@
+package runrush.be.runningrecord.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import runrush.be.user.domain.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "running_record")
+public class RunningRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Lob
+    @Column(name = "path_geo_json", columnDefinition = "TEXT")
+    private String pathGeoJson;
+
+    @Column(name = "total_distance")
+    private double totalDistance;
+
+    @Column(name = "start_latitude")
+    private double startLatitude;
+
+    @Column(name = "start_longitude")
+    private double startLongitude;
+
+    @Column(name = "end_latitude")
+    private double endLatitude;
+
+    @Column(name = "end_longitude")
+    private double endLongitude;
+
+    @Column(name = "started_time")
+    private LocalDateTime startedTime;
+
+    @Column(name = "ended_time")
+    private LocalDateTime endedTime;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Builder
+    public RunningRecord(
+            User user,
+            String pathGeoJson,
+            double totalDistance,
+            double startLatitude,
+            double startLongitude,
+            double endLatitude,
+            double endLongitude,
+            LocalDateTime startedTime,
+            LocalDateTime endedTime
+    ) {
+        this.user = user;
+        this.pathGeoJson = pathGeoJson;
+        this.totalDistance = totalDistance;
+        this.startLatitude = startLatitude;
+        this.startLongitude = startLongitude;
+        this.endLatitude = endLatitude;
+        this.endLongitude = endLongitude;
+        this.startedTime = startedTime;
+        this.endedTime = endedTime;
+    }
+}

--- a/src/main/java/runrush/be/runningrecord/domain/RunningRecord.java
+++ b/src/main/java/runrush/be/runningrecord/domain/RunningRecord.java
@@ -54,6 +54,11 @@ public class RunningRecord {
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
+    @Column(name = "total_time")
+    private long totalTime;
+
+    private double pace;
+
     @Builder
     public RunningRecord(
             User user,
@@ -64,7 +69,9 @@ public class RunningRecord {
             double endLatitude,
             double endLongitude,
             LocalDateTime startedTime,
-            LocalDateTime endedTime
+            LocalDateTime endedTime,
+            long totalTime,
+            double pace
     ) {
         this.user = user;
         this.pathGeoJson = pathGeoJson;
@@ -75,5 +82,7 @@ public class RunningRecord {
         this.endLongitude = endLongitude;
         this.startedTime = startedTime;
         this.endedTime = endedTime;
+        this.totalTime = totalTime;
+        this.pace = pace;
     }
 }

--- a/src/main/java/runrush/be/runningrecord/dto/RunningRecordListResponse.java
+++ b/src/main/java/runrush/be/runningrecord/dto/RunningRecordListResponse.java
@@ -1,0 +1,21 @@
+package runrush.be.runningrecord.dto;
+
+import runrush.be.runningrecord.domain.RunningRecord;
+
+import java.time.LocalDateTime;
+
+public record RunningRecordListResponse(
+        Long id,
+        double totalDistance,
+        long totalTime,
+        LocalDateTime startedTime
+) {
+    public static RunningRecordListResponse toRecordListResponse(RunningRecord record) {
+        return new RunningRecordListResponse(
+                record.getId(),
+                record.getTotalDistance(),
+                record.getTotalTime(),
+                record.getStartedTime()
+        );
+    }
+}

--- a/src/main/java/runrush/be/runningrecord/dto/RunningRecordRequest.java
+++ b/src/main/java/runrush/be/runningrecord/dto/RunningRecordRequest.java
@@ -1,0 +1,15 @@
+package runrush.be.runningrecord.dto;
+
+import java.time.LocalDateTime;
+
+public record RunningRecordRequest(
+        String email,
+        String pathGeoJson,
+        double startLatitude,
+        double startLongitude,
+        double endLatitude,
+        double endLongitude,
+        LocalDateTime startedTime,
+        LocalDateTime endedTime
+) {
+}

--- a/src/main/java/runrush/be/runningrecord/dto/RunningRecordRequest.java
+++ b/src/main/java/runrush/be/runningrecord/dto/RunningRecordRequest.java
@@ -3,7 +3,6 @@ package runrush.be.runningrecord.dto;
 import java.time.LocalDateTime;
 
 public record RunningRecordRequest(
-        String email,
         String pathGeoJson,
         double startLatitude,
         double startLongitude,

--- a/src/main/java/runrush/be/runningrecord/dto/RunningRecordResponse.java
+++ b/src/main/java/runrush/be/runningrecord/dto/RunningRecordResponse.java
@@ -1,0 +1,35 @@
+package runrush.be.runningrecord.dto;
+
+import runrush.be.runningrecord.domain.RunningRecord;
+
+import java.time.LocalDateTime;
+
+public record RunningRecordResponse(
+        Long id,
+        double totalDistance,
+        long totalTime,
+        double pace,
+        LocalDateTime startedTime,
+        LocalDateTime endedTime,
+        double startLatitude,
+        double startLongitude,
+        double endLatitude,
+        double endLongitude,
+        String pathGeoJson
+) {
+    public static RunningRecordResponse toRecordResponse(RunningRecord record) {
+        return new RunningRecordResponse(
+                record.getId(),
+                record.getTotalDistance(),
+                record.getTotalTime(),
+                record.getPace(),
+                record.getStartedTime(),
+                record.getEndedTime(),
+                record.getStartLatitude(),
+                record.getStartLongitude(),
+                record.getEndLatitude(),
+                record.getEndLongitude(),
+                record.getPathGeoJson()
+        );
+    }
+}

--- a/src/main/java/runrush/be/runningrecord/repository/RunningRecordRepository.java
+++ b/src/main/java/runrush/be/runningrecord/repository/RunningRecordRepository.java
@@ -1,0 +1,9 @@
+package runrush.be.runningrecord.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import runrush.be.runningrecord.domain.RunningRecord;
+
+@Repository
+public interface RunningRecordRepository extends JpaRepository<RunningRecord, Long> {
+}

--- a/src/main/java/runrush/be/runningrecord/repository/RunningRecordRepository.java
+++ b/src/main/java/runrush/be/runningrecord/repository/RunningRecordRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import runrush.be.runningrecord.domain.RunningRecord;
 
+import java.util.List;
+
 @Repository
 public interface RunningRecordRepository extends JpaRepository<RunningRecord, Long> {
+    List<RunningRecord> findByUserEmail(String email);
 }

--- a/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
+++ b/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
@@ -1,0 +1,61 @@
+package runrush.be.runningrecord.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import runrush.be.runningrecord.dto.RunningRecordRequest;
+import runrush.be.runningrecord.repository.RunningRecordRepository;
+import runrush.be.user.domain.User;
+import runrush.be.user.service.UserService;
+
+@Service
+@RequiredArgsConstructor
+public class RunningRecordService {
+    private final RunningRecordRepository runningRecordRepository;
+    private final UserService userService;
+
+    @Transactional
+    public void save(RunningRecordRequest request) throws JsonProcessingException {
+        User user = userService.findUserByEmail(request.email());
+    }
+
+
+    private double calculateTotalDistance(String pathGeoJson) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(pathGeoJson);
+        JsonNode coordinates = jsonNode.get("coordinates");
+
+        double totalDistance = 0.0;
+
+        for (int i = 1; i < coordinates.size(); i++) {
+            JsonNode prev = coordinates.get(i - 1);
+            JsonNode curr = coordinates.get(i);
+
+            double lon1 = prev.get(0).asDouble();
+            double lat1 = prev.get(1).asDouble();
+            double lon2 = curr.get(0).asDouble();
+            double lat2 = curr.get(1).asDouble();
+
+            totalDistance += haversine(lat1, lon1, lat2, lon2);
+        }
+
+        return totalDistance;
+    }
+
+    private double haversine(double lat1, double lon1, double lat2, double lon2) {
+        int R = 6371;
+
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c * 1000;
+    }
+}

--- a/src/main/java/runrush/be/user/service/UserService.java
+++ b/src/main/java/runrush/be/user/service/UserService.java
@@ -2,6 +2,7 @@ package runrush.be.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import runrush.be.user.domain.User;
 import runrush.be.user.repository.UserRepository;
 
@@ -10,6 +11,7 @@ import runrush.be.user.repository.UserRepository;
 public class UserService {
     private final UserRepository userRepository;
 
+    @Transactional(readOnly = true)
     public User findUserByEmail(String email) {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));


### PR DESCRIPTION
✨ 작업 내용
- 러닝 기록 저장을 위한 RunningRecord 엔티티 생성
- 거리·시간·페이스 계산 및 저장 로직 구현
- 러닝 경로 기반 거리 계산 기능 추가
- 러닝 기록 저장 요청/응답 DTO 생성 (RunningRecordRequest, RunningRecordResponse, RunningRecordListResponse)
- 사용자 이메일 기반 러닝 기록 조회 메서드 구현
- 러닝 기록 등록 및 조회 API 컨트롤러 구현
- 거리 계산 중 잘못된 좌표 형식 예외 처리 추가
- JPA Auditing 활성화를 위한 @EnableJpaAuditing 설정 추가
- findUserByEmail에 읽기 전용 트랜잭션 적용으로 성능 최적화

### 🎯 관련 이슈
- #6 