### PR TITLE
카카오 로그인 + JWT 인증 개선 및 추천 코스 구조 리팩토링

### DIFF
--- a/src/main/java/runrush/be/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/runrush/be/auth/jwt/JwtTokenProvider.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import runrush.be.user.domain.User;
@@ -14,6 +15,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Date;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
@@ -90,10 +92,15 @@ public class JwtTokenProvider {
             return false;
         }
 
-        Jwts.parser()
-                .verifyWith(getSigningKey())
-                .build()
-                .parseSignedClaims(token);
-        return true;
+        try {
+            Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            log.warn("토큰 검증 실패: {}", e.getMessage());
+            return false;
+        }
     }
 }

--- a/src/main/java/runrush/be/auth/model/UserPrincipal.java
+++ b/src/main/java/runrush/be/auth/model/UserPrincipal.java
@@ -29,7 +29,7 @@ public class UserPrincipal implements OAuth2User, UserDetails {
         return UserPrincipal.builder()
                 .id(user.getId())
                 .email(user.getEmail())
-                .password("")
+                .password(null)
                 .authorities(authorities)
                 .attributes(attributes)
                 .build();

--- a/src/main/java/runrush/be/auth/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/runrush/be/auth/oauth2/OAuth2LoginSuccessHandler.java
@@ -6,7 +6,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -22,9 +21,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final AuthService authService;
 
-    @Value("${app.frontend.callback-url}")
-    private String callbackUrl;
-
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         log.info("OAuth2 로그인 성공");
@@ -35,9 +31,12 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         authService.setRefreshTokenCookie(email, response);
         String accessToken = authService.generateAccessToken(email);
 
-        String redirectUrl = callbackUrl + "?accessToken=" + accessToken;
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        String json = String.format("{\"accessToken\": \"%s\", \"tokenType\": \"Bearer\"}", accessToken);
+        response.getWriter().write(json);
 
-        response.sendRedirect(redirectUrl);
         log.info("OAuth2 로그인 성공 처리 완료");
     }
 }

--- a/src/main/java/runrush/be/recommendedCourse/controller/RecommendedCourseController.java
+++ b/src/main/java/runrush/be/recommendedCourse/controller/RecommendedCourseController.java
@@ -22,7 +22,7 @@ public class RecommendedCourseController {
     @PostMapping("/{courseId}")
     public ResponseEntity<Void> createCourse(@PathVariable Long courseId,
                                              @AuthenticationPrincipal UserPrincipal user) {
-        recommendedCourseService.createRecommendedCourse(courseId, user.getEmail(), user.getName());
+        recommendedCourseService.createRecommendedCourse(courseId, user.getId(), user.getName());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
@@ -30,27 +30,27 @@ public class RecommendedCourseController {
     public ResponseEntity<Void> updateCourse(@PathVariable Long courseId,
                                              @AuthenticationPrincipal UserPrincipal user,
                                              @RequestBody RecommendedCourseUpdateRequest request) {
-        recommendedCourseService.updateRecommendedCourse(courseId, user.getEmail(), request);
+        recommendedCourseService.updateRecommendedCourse(courseId, user.getId(), request);
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{courseId}")
     public ResponseEntity<Void> deleteCourse(@PathVariable Long courseId,
                                              @AuthenticationPrincipal UserPrincipal user) {
-        recommendedCourseService.deleteRecommendedCourse(courseId, user.getEmail());
+        recommendedCourseService.deleteRecommendedCourse(courseId, user.getId());
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/{courseId}")
     public ResponseEntity<RecommendedCourseResponse> getCourse(@PathVariable Long courseId,
                                                                @AuthenticationPrincipal UserPrincipal user) {
-        recommendedCourseService.getRecommendedCourse(courseId, user.getEmail());
-        return ResponseEntity.ok().build();
+        RecommendedCourseResponse recommendedCourse = recommendedCourseService.getRecommendedCourse(courseId, user.getId());
+        return ResponseEntity.ok().body(recommendedCourse);
     }
 
     @GetMapping("/user")
     public ResponseEntity<List<RecommendedCourseListResponse>> getUserRecommendedCourses(@AuthenticationPrincipal UserPrincipal user) {
-        List<RecommendedCourseListResponse> userRecommendedCourses = recommendedCourseService.getUserRecommendedCourses(user.getEmail());
+        List<RecommendedCourseListResponse> userRecommendedCourses = recommendedCourseService.getUserRecommendedCourses(user.getId());
         return ResponseEntity.ok().body(userRecommendedCourses);
     }
 

--- a/src/main/java/runrush/be/recommendedCourse/domain/RecommendedCourse.java
+++ b/src/main/java/runrush/be/recommendedCourse/domain/RecommendedCourse.java
@@ -25,9 +25,8 @@ public class RecommendedCourse {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
-    @JoinColumn(name = "running_record_id")
-    @OneToOne(fetch = FetchType.LAZY)
-    private RunningRecord runningRecord;
+    @Column(name = "source_record_id")
+    private Long sourceRecordId;
 
     private String title;
 
@@ -48,12 +47,9 @@ public class RecommendedCourse {
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "is_deleted")
-    private boolean isDeleted = false;
-
     @Builder
     public RecommendedCourse(User user,
-                             RunningRecord runningRecord,
+                             Long sourceRecordId,
                              String title,
                              String description,
                              String pathGeoJson,
@@ -61,7 +57,7 @@ public class RecommendedCourse {
                              double latitude,
                              double longitude) {
         this.user = user;
-        this.runningRecord = runningRecord;
+        this.sourceRecordId = sourceRecordId;
         this.title = title;
         this.description = description;
         this.pathGeoJson = pathGeoJson;
@@ -76,9 +72,5 @@ public class RecommendedCourse {
 
     public void changeDescription(String description) {
         this.description = description;
-    }
-
-    public void delete() {
-        this.isDeleted = true;
     }
 }

--- a/src/main/java/runrush/be/recommendedCourse/dto/RecommendedCourseResponse.java
+++ b/src/main/java/runrush/be/recommendedCourse/dto/RecommendedCourseResponse.java
@@ -1,13 +1,10 @@
 package runrush.be.recommendedCourse.dto;
 
 import runrush.be.recommendedCourse.domain.RecommendedCourse;
-import runrush.be.runningrecord.domain.RunningRecord;
-import runrush.be.user.domain.User;
 
 public record RecommendedCourseResponse(
         Long courseId,
         String userName,
-        RunningRecord runningRecord,
         String title,
         String description,
         String pathGeoJson,
@@ -19,7 +16,6 @@ public record RecommendedCourseResponse(
         return new RecommendedCourseResponse(
                 course.getId(),
                 course.getUser().getName(),
-                course.getRunningRecord(),
                 course.getTitle(),
                 course.getDescription(),
                 course.getPathGeoJson(),

--- a/src/main/java/runrush/be/recommendedCourse/repository/RecommendedCourseRepository.java
+++ b/src/main/java/runrush/be/recommendedCourse/repository/RecommendedCourseRepository.java
@@ -3,16 +3,12 @@ package runrush.be.recommendedCourse.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import runrush.be.recommendedCourse.domain.RecommendedCourse;
-import runrush.be.runningrecord.domain.RunningRecord;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface RecommendedCourseRepository extends JpaRepository<RecommendedCourse, Long> {
-    boolean existsByRunningRecord(RunningRecord runningRecord);
-    Optional<RecommendedCourse> findByIdAndIsDeletedFalse(Long courseId);
-    List<RecommendedCourse> findAllByIsDeletedFalse();
-    List<RecommendedCourse> findByUserEmailAndIsDeletedFalse(String email);
+    boolean existsBySourceRecordId(Long sourceRecordId);
 
+    List<RecommendedCourse> findByUserId(Long userId);
 }

--- a/src/main/java/runrush/be/runningrecord/controller/RunningRecordController.java
+++ b/src/main/java/runrush/be/runningrecord/controller/RunningRecordController.java
@@ -22,13 +22,13 @@ public class RunningRecordController {
     @PostMapping
     public ResponseEntity<Void> createRunningRecord(@AuthenticationPrincipal UserPrincipal user,
                                                     @RequestBody RunningRecordRequest request) {
-        runningRecordService.saveRunningRecord(request, user.getEmail());
+        runningRecordService.saveRunningRecord(request, user.getId());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @GetMapping
     public ResponseEntity<List<RunningRecordListResponse>> getRunningRecords(@AuthenticationPrincipal UserPrincipal user) {
-        List<RunningRecordListResponse> runningRecords = runningRecordService.getRunningRecords(user.getEmail());
+        List<RunningRecordListResponse> runningRecords = runningRecordService.getRunningRecords(user.getId());
         return ResponseEntity.ok(runningRecords);
     }
 
@@ -42,7 +42,7 @@ public class RunningRecordController {
     @DeleteMapping("/{recordId}")
     public ResponseEntity<Void> deleteRunningRecord(@PathVariable Long recordId,
                                                     @AuthenticationPrincipal UserPrincipal user) {
-        runningRecordService.deleteRunningRecord(recordId, user.getEmail());
+        runningRecordService.deleteRunningRecord(recordId, user.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/runrush/be/runningrecord/repository/RunningRecordRepository.java
+++ b/src/main/java/runrush/be/runningrecord/repository/RunningRecordRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 @Repository
 public interface RunningRecordRepository extends JpaRepository<RunningRecord, Long> {
     Optional<RunningRecord> findByIdAndIsDeletedFalse(Long id);
-    List<RunningRecord> findByUserEmailAndIsDeletedFalse(String email);
+    List<RunningRecord> findByUserIdAndIsDeletedFalse(Long userId);
 }

--- a/src/main/java/runrush/be/user/controller/UserController.java
+++ b/src/main/java/runrush/be/user/controller/UserController.java
@@ -23,7 +23,7 @@ public class UserController {
             return ResponseEntity.status(401).build();
         }
 
-        User userByEmail = userService.findUserByEmail(user.getEmail());
+        User userByEmail = userService.findUserById(user.getId());
         UserInfoResponse userInfoResponse = UserInfoResponse.fromEntity(userByEmail);
         return ResponseEntity.ok(userInfoResponse);
     }

--- a/src/main/java/runrush/be/user/service/UserService.java
+++ b/src/main/java/runrush/be/user/service/UserService.java
@@ -16,4 +16,10 @@ public class UserService {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
     }
+
+    @Transactional(readOnly = true)
+    public User findUserById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. ID=" + id));
+    }
 }


### PR DESCRIPTION
## ✨ 작업 내용

- 카카오 로그인 이후 AccessToken 전달 방식을 쿼리 파라미터 → HTTP 응답 본문(JSON)으로 개선하여 보안 강화  
- JWT 토큰 검증 시 예외 처리 및 로그 추가로 디버깅 편의성 확보  
- JWT 내부 식별자를 email → userId로 변경하고 서비스 계층 전반 리팩토링  
- `UserDetails.password` 필드 null 처리로 불필요한 데이터 제거  
- 러닝 페이스 계산에 `BigDecimal + RoundingMode` 적용하여 정밀도 향상  
- GeoJSON 유효성 검증 로직 추가  
- 러닝 기록(RunningRecord)은 소프트 삭제 유지 → 복구 가능성 확보  
- 추천 코스(RecommendedCourse)는 하드 삭제로 변경하여 즉시 삭제 보장  
- 추천 코스와 러닝 기록 간 연관 관계 제거 → 추천 코스는 독립적으로 유지  
- 추천 중복 생성을 방지하기 위해 `sourceRecordId` 필드 도입 및 중복 체크 로직 적용

---

## 🔄 변경 요약

- 추천 코스 생성 시 `userId`와 `sourceRecordId`를 기반으로 추천 중복 여부 판단  
- 기존 시작 좌표(`startLatitude`, `startLongitude`) 대신 끝 좌표(`endLatitude`, `endLongitude`)를 저장하도록 변경  
- 사용자 검증 방식을 `email` → `userId` 중심으로 일괄 변경  
- 추천 코스의 soft delete 방식 제거 및 관련 불필요한 로직 정리

---

## 🎯 관련 이슈

- #10 