### PR TITLE
러닝 기록 저장 시 거리 기반 경험치 부여 및 등급 자동 갱신 기능 추가

### DIFF
--- a/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
+++ b/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
@@ -33,6 +33,9 @@ public class RunningRecordService {
         double totalDistance = calculateTotalDistance(request.pathGeoJson());
         long totalTime = Duration.between(request.startedTime(), request.endedTime()).getSeconds();
 
+        int exp = (int) (totalDistance / 10);
+        user.addExperiencePoints(exp);
+
         BigDecimal minutes = BigDecimal.valueOf(totalTime)
                 .divide(BigDecimal.valueOf(60), 10, RoundingMode.HALF_UP);
         BigDecimal kilometers = BigDecimal.valueOf(totalDistance)

--- a/src/main/java/runrush/be/user/domain/Level.java
+++ b/src/main/java/runrush/be/user/domain/Level.java
@@ -4,7 +4,8 @@ public enum Level {
     BEGINNER(1, "초보 러너", 0, 100),
     INTERMEDIATE(2, "열정 러너", 100, 300),
     ADVANCED(3, "숙련 러너", 300, 600),
-    EXPERT(4, "엘리트 러너", 600, 1000);
+    EXPERT(4, "엘리트 러너", 600, 1000),
+    MASTER(5, "마스터 러너", 1000, Integer.MAX_VALUE);
 
     private final int value;
     private final String title;
@@ -16,5 +17,14 @@ public enum Level {
         this.title = title;
         this.minExp = minExp;
         this.maxExp = maxExp;
+    }
+
+    public static Level fromExperiencePoints(int exp) {
+        for (Level level : Level.values()) {
+            if (exp >= level.minExp && exp < level.maxExp) {
+                return level;
+            }
+        }
+        return MASTER;
     }
 }

--- a/src/main/java/runrush/be/user/domain/User.java
+++ b/src/main/java/runrush/be/user/domain/User.java
@@ -39,4 +39,9 @@ public class User {
         this.level = Level.BEGINNER;
         this.experiencePoints = 0;
     }
+
+    public void addExperiencePoints(int points) {
+        this.experiencePoints += points;
+        this.level = Level.fromExperiencePoints(experiencePoints);
+    }
 }


### PR DESCRIPTION
### ✨ 작업 내용
- 러닝 기록 저장 시 총 거리 기준으로 사용자에게 경험치를 부여하는 기능을 추가했습니다. (10m당 1점)
- 누적 경험치를 기반으로 `Level.fromExperiencePoints()` 메서드를 통해 자동으로 사용자 등급이 갱신됩니다.
- 사용자 정보 응답 DTO(`UserInfoResponse`)에 현재 등급명이 포함되어 프론트엔드에서 등급 정보를 표시할 수 있습니다.

### 🎯 관련 이슈
- #12 