### PR TITLE
추천 코스 및 북마크 조회 시 N+1 문제 해결 및 인증 처리 개선

### DIFF
--- a/src/main/java/runrush/be/auth/controller/AuthController.java
+++ b/src/main/java/runrush/be/auth/controller/AuthController.java
@@ -33,7 +33,7 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/reissue")
+    @PostMapping("/refresh")
     public ResponseEntity<?> reissue(HttpServletRequest request) {
         String refreshToken = getRefreshTokenFromCookie(request);
         String accessToken = authService.reissueAccessToken(refreshToken);

--- a/src/main/java/runrush/be/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/runrush/be/auth/jwt/JwtAuthenticationFilter.java
@@ -50,6 +50,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             } catch (Exception e) {
                 log.error("JWT 인증 처리 중 오류 발생: {}", e.getMessage());
                 SecurityContextHolder.clearContext();
+
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "토큰이 유효하지 않거나 만료되었습니다.");
+                return;
             }
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/runrush/be/coursebookmark/repository/CourseBookmarkRepository.java
+++ b/src/main/java/runrush/be/coursebookmark/repository/CourseBookmarkRepository.java
@@ -1,6 +1,7 @@
 package runrush.be.coursebookmark.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import runrush.be.coursebookmark.domain.CourseBookmark;
 
@@ -10,5 +11,10 @@ import java.util.Optional;
 @Repository
 public interface CourseBookmarkRepository extends JpaRepository<CourseBookmark, Long> {
     Optional<CourseBookmark> findByUserIdAndRecommendedCourseId(Long userId, Long courseId);
-    List<CourseBookmark> findByUserId(Long userId);
+
+    @Query("SELECT cb FROM CourseBookmark cb " +
+            "JOIN FETCH cb.recommendedCourse " +
+            "WHERE cb.user.id = :userId " +
+            "ORDER BY cb.bookmarkedAt DESC")
+    List<CourseBookmark> findWithCourseByUserId(Long userId);
 }

--- a/src/main/java/runrush/be/coursebookmark/service/CourseBookmarkService.java
+++ b/src/main/java/runrush/be/coursebookmark/service/CourseBookmarkService.java
@@ -54,7 +54,7 @@ public class CourseBookmarkService {
 
     @Transactional(readOnly = true)
     public List<BookmarkedCourseListResponse> getBookmarkedCourses(Long userId) {
-        return courseBookmarkRepository.findByUserId(userId).stream()
+        return courseBookmarkRepository.findWithCourseByUserId(userId).stream()
                 .map(course -> BookmarkedCourseListResponse.toBookmarkedCourseListResponse(course.getRecommendedCourse(), course.getId()))
                 .toList();
     }

--- a/src/main/java/runrush/be/recommendedCourse/controller/RecommendedCourseController.java
+++ b/src/main/java/runrush/be/recommendedCourse/controller/RecommendedCourseController.java
@@ -43,13 +43,13 @@ public class RecommendedCourseController {
 
     @GetMapping("/{courseId}")
     public ResponseEntity<RecommendedCourseResponse> getCourse(@PathVariable Long courseId) {
-        RecommendedCourseResponse recommendedCourse = recommendedCourseService.getRecommendedCourse(courseId);
+        RecommendedCourseResponse recommendedCourse = recommendedCourseService.getRecommendedCourseDetail(courseId);
         return ResponseEntity.ok().body(recommendedCourse);
     }
 
     @GetMapping("/my")
     public ResponseEntity<List<RecommendedCourseListResponse>> getMyRecommendedCourses(@AuthenticationPrincipal UserPrincipal user) {
-        List<RecommendedCourseListResponse> myRecommendedCourses = recommendedCourseService.getUserRecommendedCourses(user.getId());
+        List<RecommendedCourseListResponse> myRecommendedCourses = recommendedCourseService.getMyRecommendedCourses(user.getId());
         return ResponseEntity.ok().body(myRecommendedCourses);
     }
 

--- a/src/main/java/runrush/be/recommendedCourse/repository/RecommendedCourseRepository.java
+++ b/src/main/java/runrush/be/recommendedCourse/repository/RecommendedCourseRepository.java
@@ -1,14 +1,29 @@
 package runrush.be.recommendedCourse.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import runrush.be.recommendedCourse.domain.RecommendedCourse;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RecommendedCourseRepository extends JpaRepository<RecommendedCourse, Long> {
     boolean existsBySourceRecordId(Long sourceRecordId);
 
-    List<RecommendedCourse> findByUserId(Long userId);
+    @Query("SELECT rc FROM RecommendedCourse rc " +
+            "JOIN FETCH rc.user " +
+            "WHERE rc.user.id = :userId")
+    List<RecommendedCourse> findWithUserByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT rc FROM RecommendedCourse rc " +
+            "JOIN FETCH rc.user ")
+    List<RecommendedCourse> findAllWithUser();
+
+    @Query("SELECT rc FROM RecommendedCourse rc " +
+            "JOIN FETCH rc.user " +
+            "WHERE rc.id = :courseId")
+    Optional<RecommendedCourse> findByCourseId(@Param("courseId") Long courseId);
 }

--- a/src/main/java/runrush/be/recommendedCourse/service/RecommendedCourseService.java
+++ b/src/main/java/runrush/be/recommendedCourse/service/RecommendedCourseService.java
@@ -74,23 +74,23 @@ public class RecommendedCourseService {
     }
 
     @Transactional(readOnly = true)
-    public RecommendedCourseResponse getRecommendedCourse(Long courseId) {
-        RecommendedCourse recommendedCourse = recommendedCourseRepository.findById(courseId)
+    public RecommendedCourseResponse getRecommendedCourseDetail(Long courseId) {
+        RecommendedCourse recommendedCourse = recommendedCourseRepository.findByCourseId(courseId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 코스입니다."));
 
         return RecommendedCourseResponse.toCourseResponse(recommendedCourse);
     }
 
     @Transactional(readOnly = true)
-    public List<RecommendedCourseListResponse> getUserRecommendedCourses(Long userId) {
-        return recommendedCourseRepository.findByUserId(userId).stream()
+    public List<RecommendedCourseListResponse> getMyRecommendedCourses(Long userId) {
+        return recommendedCourseRepository.findWithUserByUserId(userId).stream()
                 .map(RecommendedCourseListResponse::toCourseListResponse)
                 .toList();
     }
 
     @Transactional(readOnly = true)
     public List<RecommendedCourseListResponse> getRecommendedCourses() {
-        return recommendedCourseRepository.findAll().stream()
+        return recommendedCourseRepository.findAllWithUser().stream()
                 .map(RecommendedCourseListResponse::toCourseListResponse)
                 .toList();
     }


### PR DESCRIPTION
### ✨ 작업 내용
- **CourseBookmarkRepository**에 `JOIN FETCH` 쿼리를 적용하여 **북마크 목록 조회 시 추천 코스 정보를 함께 로딩**하도록 수정했습니다.
- **CourseBookmarkService**에서는 `findWithCourseByUserId` 메서드를 사용하여 **N+1 문제를 해결**하였습니다.
- **추천 코스 조회 시 사용자(User) 정보도 함께 로딩**되도록 Repository에 `JOIN FETCH` 쿼리를 추가하고, 서비스 로직도 이에 맞춰 리팩토링했습니다.
- 서비스 메서드 및 컨트롤러 메서드 명칭을 보다 명확하고 일관성 있게 리네이밍하였습니다.
- JWT 인증 실패 시 401 Unauthorized 응답을 반환하여 클라이언트가 **명확한 인증 실패 원인을 인지**할 수 있도록 처리하였습니다.
- 리프레시 토큰 재발급 엔드포인트 URL을 `/reissue`에서 `/refresh`로 변경하여 **명확한 RESTful 설계**를 반영했습니다.

### 🎯 관련 이슈
- #16 