### PR TITLE
OAuth2 로그인 리디렉션 및 액세스 토큰 재발급 흐름 구현

### DIFF
--- a/src/main/java/runrush/be/auth/controller/AuthController.java
+++ b/src/main/java/runrush/be/auth/controller/AuthController.java
@@ -7,11 +7,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import runrush.be.auth.domain.RefreshToken;
 import runrush.be.auth.service.AuthService;
+import runrush.be.auth.service.RefreshTokenService;
 
+import java.time.Instant;
 import java.util.Map;
 
 @Slf4j
@@ -21,6 +25,7 @@ import java.util.Map;
 public class AuthController {
 
     private final AuthService authService;
+    private final RefreshTokenService refreshTokenService;
 
     @PostMapping("/logout")
     public ResponseEntity<String> logout(
@@ -43,6 +48,26 @@ public class AuthController {
                 "token_type", "Bearer"
         ));
     }
+
+    @GetMapping("/token")
+    public ResponseEntity<?> getAccessToken(HttpServletRequest request) {
+        String refreshToken = getRefreshTokenFromCookie(request);
+
+        RefreshToken token = refreshTokenService.findByToken(refreshToken)
+                .orElseThrow(() -> new RuntimeException("유효하지 않은 리프레시 토큰입니다."));
+
+        if (token.getExpiresAt().isBefore(Instant.now())) {
+            throw new RuntimeException("리프레시 토큰이 만료되었습니다.");
+        }
+
+        String accessToken = authService.generateAccessToken(token.getUserEmail());
+
+        return ResponseEntity.ok(Map.of(
+                "access_token", accessToken,
+                "token_type", "Bearer"
+        ));
+    }
+
 
     private String getRefreshTokenFromCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();

--- a/src/main/java/runrush/be/auth/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/runrush/be/auth/oauth2/OAuth2LoginSuccessHandler.java
@@ -6,9 +6,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 import runrush.be.auth.model.UserPrincipal;
 import runrush.be.auth.service.AuthService;
 
@@ -21,22 +23,33 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final AuthService authService;
 
+    @Value("${app.oauth2.redirect-uri}")
+    private String redirectUri;
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-        log.info("OAuth2 로그인 성공");
+        try {
 
-        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
-        String email = userPrincipal.getEmail();
+            UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+            String email = userPrincipal.getEmail();
 
-        authService.setRefreshTokenCookie(email, response);
-        String accessToken = authService.generateAccessToken(email);
+            authService.setRefreshTokenCookie(email, response);
 
-        response.setStatus(HttpServletResponse.SC_OK);
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-        String json = String.format("{\"accessToken\": \"%s\", \"tokenType\": \"Bearer\"}", accessToken);
-        response.getWriter().write(json);
+            String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+                    .queryParam("success", true)
+                    .build().toUriString();
 
-        log.info("OAuth2 로그인 성공 처리 완료");
+            response.sendRedirect(targetUrl);
+
+            log.info("OAuth2 로그인 성공 - 리다이렉트: {}", targetUrl);
+
+        } catch (Exception e) {
+            log.error("OAuth2 로그인 처리 중 오류 발생", e);
+            String errorUrl = UriComponentsBuilder.fromUriString(redirectUri)
+                    .queryParam("success", false)
+                    .build().toUriString();
+
+            response.sendRedirect(errorUrl);
+        }
     }
 }

--- a/src/main/java/runrush/be/config/SecurityConfig.java
+++ b/src/main/java/runrush/be/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/oauth2/**", "/login/**").permitAll()
+                        .requestMatchers("/oauth2/**", "/login/**", "/auth/token", "/auth/refresh").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2


### PR DESCRIPTION
### ✨ 작업 내용
- OAuth2 로그인 성공 후 액세스 토큰을 직접 반환하지 않고, 프론트엔드 리디렉션 방식으로 변경
- 리프레시 토큰 기반 액세스 토큰 재발급 엔드포인트 추가 (GET /auth/token)
- 인증 예외 경로에 /auth/token, /auth/refresh 추가

### 🎯 관련 이슈
- #18 