### PR TITLE
추천 코스 좋아요 기능 및 정렬 기능 구현

### DIFF
--- a/src/main/java/runrush/be/like/controller/LikeController.java
+++ b/src/main/java/runrush/be/like/controller/LikeController.java
@@ -1,0 +1,25 @@
+package runrush.be.like.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import runrush.be.auth.model.UserPrincipal;
+import runrush.be.like.service.LikeService;
+
+@RestController
+@RequestMapping("/like")
+@RequiredArgsConstructor
+public class LikeController {
+    private final LikeService likeService;
+
+    @PostMapping("/{courseId}")
+    public ResponseEntity<Void> toggleLike(@PathVariable Long courseId,
+                                           @AuthenticationPrincipal UserPrincipal user) {
+        likeService.likeToggle(user.getId(), courseId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/runrush/be/like/domain/Like.java
+++ b/src/main/java/runrush/be/like/domain/Like.java
@@ -1,0 +1,34 @@
+package runrush.be.like.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import runrush.be.recommendedCourse.domain.RecommendedCourse;
+import runrush.be.user.domain.User;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "recommended_course_id"})
+})
+public class Like {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "recommended_course_id")
+    private RecommendedCourse recommendedCourse;
+
+    @Builder
+    public Like(User user, RecommendedCourse recommendedCourse) {
+        this.user = user;
+        this.recommendedCourse = recommendedCourse;
+    }
+}

--- a/src/main/java/runrush/be/like/repository/LikeRepository.java
+++ b/src/main/java/runrush/be/like/repository/LikeRepository.java
@@ -1,0 +1,17 @@
+package runrush.be.like.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import runrush.be.like.domain.Like;
+
+import java.util.Optional;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    @Query("SELECT l FROM Like l WHERE l.user.id = :userId AND l.recommendedCourse.id = :corseId")
+    Optional<Like> findByUserIdAndRecommendedCourseId(@Param("userId") Long userId,
+                                                      @Param("courseId") Long courseId);
+}

--- a/src/main/java/runrush/be/like/service/LikeService.java
+++ b/src/main/java/runrush/be/like/service/LikeService.java
@@ -1,0 +1,45 @@
+package runrush.be.like.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import runrush.be.like.domain.Like;
+import runrush.be.like.repository.LikeRepository;
+import runrush.be.recommendedCourse.domain.RecommendedCourse;
+import runrush.be.recommendedCourse.repository.RecommendedCourseRepository;
+import runrush.be.user.domain.User;
+import runrush.be.user.service.UserService;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+    private final LikeRepository likeRepository;
+    private final UserService userService;
+    private final RecommendedCourseRepository recommendedCourseRepository;
+
+
+    @Transactional
+    public void likeToggle(Long userId, Long courseId) {
+        User user = userService.findUserById(userId);
+        RecommendedCourse recommendedCourse = recommendedCourseRepository.findById(courseId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 코스입니다."));
+
+        Optional<Like> existsLike = likeRepository.findByUserIdAndRecommendedCourseId(userId, courseId);
+        if (existsLike.isPresent()) {
+            likeRepository.delete(existsLike.get());
+            log.info("좋아요 해제: courseId={}", courseId);
+
+        } else {
+            Like like = Like.builder()
+                    .user(user)
+                    .recommendedCourse(recommendedCourse)
+                    .build();
+            likeRepository.save(like);
+            log.info("북마크 추가: courseId={}", courseId);
+        }
+    }
+}

--- a/src/main/java/runrush/be/recommendedCourse/controller/RecommendedCourseController.java
+++ b/src/main/java/runrush/be/recommendedCourse/controller/RecommendedCourseController.java
@@ -9,6 +9,7 @@ import runrush.be.auth.model.UserPrincipal;
 import runrush.be.recommendedCourse.dto.RecommendedCourseListResponse;
 import runrush.be.recommendedCourse.dto.RecommendedCourseResponse;
 import runrush.be.recommendedCourse.dto.RecommendedCourseUpdateRequest;
+import runrush.be.recommendedCourse.enums.SortType;
 import runrush.be.recommendedCourse.service.RecommendedCourseService;
 
 import java.util.List;
@@ -54,8 +55,9 @@ public class RecommendedCourseController {
     }
 
     @GetMapping
-    public ResponseEntity<List<RecommendedCourseListResponse>> getAllRecommendedCourses() {
-        List<RecommendedCourseListResponse> recommendedCourses = recommendedCourseService.getRecommendedCourses();
+    public ResponseEntity<List<RecommendedCourseListResponse>> getAllRecommendedCourses(
+            @RequestParam(defaultValue = "LIKE") SortType sortType) {
+        List<RecommendedCourseListResponse> recommendedCourses = recommendedCourseService.getRecommendedCourses(sortType);
         return ResponseEntity.ok().body(recommendedCourses);
     }
 }

--- a/src/main/java/runrush/be/recommendedCourse/enums/SortType.java
+++ b/src/main/java/runrush/be/recommendedCourse/enums/SortType.java
@@ -1,0 +1,7 @@
+package runrush.be.recommendedCourse.enums;
+
+public enum SortType {
+    LIKE,
+    DISTANCE,
+    RECENT
+}

--- a/src/main/java/runrush/be/recommendedCourse/repository/RecommendedCourseRepository.java
+++ b/src/main/java/runrush/be/recommendedCourse/repository/RecommendedCourseRepository.java
@@ -26,4 +26,24 @@ public interface RecommendedCourseRepository extends JpaRepository<RecommendedCo
             "JOIN FETCH rc.user " +
             "WHERE rc.id = :courseId")
     Optional<RecommendedCourse> findByCourseId(@Param("courseId") Long courseId);
+
+    //좋아요순 정렬
+    @Query("SELECT rc FROM RecommendedCourse rc " +
+            "LEFT JOIN Like l ON l.recommendedCourse.id = rc.id " +
+            "JOIN FETCH rc.user " +
+            "GROUP BY rc.id " +
+            "ORDER BY COUNT(l.id) DESC")
+    List<RecommendedCourse> findAllOrderedByLikeCount();
+
+    // 거리순 정렬
+    @Query("SELECT rc FROM RecommendedCourse rc " +
+            "JOIN FETCH rc.user " +
+            "ORDER BY rc.totalDistance DESC")
+    List<RecommendedCourse> findAllOrderedByTotalDistance();
+
+    // 최신순 정렬
+    @Query("SELECT rc FROM RecommendedCourse rc " +
+            "JOIN FETCH rc.user " +
+            "ORDER BY rc.createdAt DESC")
+    List<RecommendedCourse> findAllOrderedByCreatedAt();
 }

--- a/src/main/java/runrush/be/recommendedCourse/service/RecommendedCourseService.java
+++ b/src/main/java/runrush/be/recommendedCourse/service/RecommendedCourseService.java
@@ -7,6 +7,7 @@ import runrush.be.recommendedCourse.domain.RecommendedCourse;
 import runrush.be.recommendedCourse.dto.RecommendedCourseListResponse;
 import runrush.be.recommendedCourse.dto.RecommendedCourseResponse;
 import runrush.be.recommendedCourse.dto.RecommendedCourseUpdateRequest;
+import runrush.be.recommendedCourse.enums.SortType;
 import runrush.be.recommendedCourse.repository.RecommendedCourseRepository;
 import runrush.be.runningrecord.domain.RunningRecord;
 import runrush.be.runningrecord.service.RunningRecordService;
@@ -92,9 +93,18 @@ public class RecommendedCourseService {
     }
 
     @Transactional(readOnly = true)
-    public List<RecommendedCourseListResponse> getRecommendedCourses() {
-        return recommendedCourseRepository.findAllWithUser().stream()
-                .map(RecommendedCourseListResponse::toCourseListResponse)
-                .toList();
+    public List<RecommendedCourseListResponse> getRecommendedCourses(SortType sortType) {
+        return switch (sortType) {
+            case LIKE -> recommendedCourseRepository.findAllOrderedByLikeCount().stream()
+                    .map(RecommendedCourseListResponse::toCourseListResponse)
+                    .toList();
+            case DISTANCE -> recommendedCourseRepository.findAllOrderedByTotalDistance().stream()
+                    .map(RecommendedCourseListResponse::toCourseListResponse)
+                    .toList();
+            case RECENT -> recommendedCourseRepository.findAllOrderedByCreatedAt().stream()
+                    .map(RecommendedCourseListResponse::toCourseListResponse)
+                    .toList();
+        };
     }
+
 }


### PR DESCRIPTION
## ✨ 작업 내용
- 추천 러닝 코스에 좋아요 기능을 추가했습니다.
- 사용자는 각 추천 코스 상세 페이지에서 좋아요 버튼을 눌러 해당 코스를 좋아하거나 취소할 수 있습니다.
- 한 사용자는 하나의 코스에 대해서만 한 번 좋아요를 누를 수 있으며, 중복 방지를 위해 유니크 제약을 추가했습니다.
- 좋아요 수에 따라 추천 코스 목록을 좋아요순(LIKE), 거리순(DISTANCE), 최신순(RECENT)으로 정렬할 수 있는 기능을 제공하며, 기본 정렬은 좋아요순입니다.
- 프론트엔드에서는 좋아요 버튼 상태 및 현재 좋아요 개수를 API를 통해 확인하고 사용자 인터랙션을 제공합니다.
- 인증된 사용자만 좋아요 기능을 사용할 수 있도록 인증 처리도 함께 구현했습니다.

## 🎯 관련 이슈
- #22 