### PR TITLE
위치 정보 중복 제거 및 비로그인 추천 코스 조회 허용

### DIFF
--- a/src/main/java/runrush/be/config/SecurityConfig.java
+++ b/src/main/java/runrush/be/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/oauth2/**", "/login/**", "/auth/token", "/auth/refresh").permitAll()
+                        .requestMatchers("/oauth2/**", "/login/**", "/auth/token", "/auth/refresh", "/course").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/runrush/be/recommendedCourse/domain/RecommendedCourse.java
+++ b/src/main/java/runrush/be/recommendedCourse/domain/RecommendedCourse.java
@@ -64,9 +64,7 @@ public class RecommendedCourse {
                              String title,
                              String description,
                              String pathGeoJson,
-                             double totalDistance,
-                             double latitude,
-                             double longitude) {
+                             double totalDistance) {
         this.user = user;
         this.sourceRecordId = sourceRecordId;
         this.imageUrl = imageUrl;
@@ -76,8 +74,6 @@ public class RecommendedCourse {
         this.description = description;
         this.pathGeoJson = pathGeoJson;
         this.totalDistance = totalDistance;
-        this.latitude = latitude;
-        this.longitude = longitude;
     }
 
     public void changeTitle(String title) {

--- a/src/main/java/runrush/be/recommendedCourse/dto/RecommendedCourseListResponse.java
+++ b/src/main/java/runrush/be/recommendedCourse/dto/RecommendedCourseListResponse.java
@@ -9,9 +9,7 @@ public record RecommendedCourseListResponse(
         String imageUrl,
         String description,
         String endLocationName,
-        double totalDistance,
-        double latitude,
-        double longitude
+        double totalDistance
 ) {
     public static RecommendedCourseListResponse toCourseListResponse(RecommendedCourse course) {
         return new RecommendedCourseListResponse(
@@ -21,9 +19,7 @@ public record RecommendedCourseListResponse(
                 course.getImageUrl(),
                 course.getDescription(),
                 course.getEndLocationName(),
-                course.getTotalDistance(),
-                course.getLatitude(),
-                course.getLongitude()
+                course.getTotalDistance()
         );
     }
 }

--- a/src/main/java/runrush/be/recommendedCourse/dto/RecommendedCourseResponse.java
+++ b/src/main/java/runrush/be/recommendedCourse/dto/RecommendedCourseResponse.java
@@ -12,9 +12,7 @@ public record RecommendedCourseResponse(
         String startLocationName,
         String endLocationName,
         JsonNode pathGeoJson,
-        double totalDistance,
-        double latitude,
-        double longitude
+        double totalDistance
 ) {
     public static RecommendedCourseResponse toCourseResponse(RecommendedCourse course) {
         return new RecommendedCourseResponse(
@@ -25,9 +23,7 @@ public record RecommendedCourseResponse(
                 course.getStartLocationName(),
                 course.getEndLocationName(),
                 GeoJsonUtil.parseGeoJson(course.getPathGeoJson()),
-                course.getTotalDistance(),
-                course.getLatitude(),
-                course.getLongitude()
+                course.getTotalDistance()
         );
     }
 }

--- a/src/main/java/runrush/be/recommendedCourse/service/RecommendedCourseService.java
+++ b/src/main/java/runrush/be/recommendedCourse/service/RecommendedCourseService.java
@@ -40,8 +40,6 @@ public class RecommendedCourseService {
                 .description("")
                 .pathGeoJson(runningRecord.getPathGeoJson())
                 .totalDistance(runningRecord.getTotalDistance())
-                .latitude(runningRecord.getEndLatitude())
-                .longitude(runningRecord.getEndLongitude())
                 .build();
 
         recommendedCourseRepository.save(course);


### PR DESCRIPTION
### ✨ 작업 내용
- `RecommendedCourse` 엔티티에서 `latitude`, `longitude` 필드를 제거했습니다.  
  이는 `pathGeoJson`과 중복되는 위치 정보를 통합하여 데이터 구조를 단순화하기 위함입니다.

- 코스 위치 정보는 이제 `GeoJSON` 형식의 `pathGeoJson` 필드로만 관리됩니다.

- `/course` 엔드포인트를 Spring Security 설정의 `permitAll` 목록에 추가했습니다.  
  이를 통해 로그인하지 않은 사용자도 추천 코스 목록을 조회할 수 있습니다.