### PR TITLE
러닝 기록 생성 시 이미지 S3 업로드 및 multipart/form-data 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+	implementation 'software.amazon.awssdk:s3:2.25.12'
+
 	/* jwt */
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/runrush/be/config/S3Config.java
+++ b/src/main/java/runrush/be/config/S3Config.java
@@ -1,0 +1,35 @@
+package runrush.be.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        if (accessKey.isEmpty() || secretKey.isEmpty()) {
+            throw new IllegalStateException("aws 권한 실패입니다.");
+        }
+
+        AwsBasicCredentials awsCre = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCre))
+                .build();
+    }
+}

--- a/src/main/java/runrush/be/runningrecord/controller/RunningRecordController.java
+++ b/src/main/java/runrush/be/runningrecord/controller/RunningRecordController.java
@@ -1,10 +1,12 @@
 package runrush.be.runningrecord.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import runrush.be.auth.model.UserPrincipal;
 import runrush.be.runningrecord.dto.RunningRecordListResponse;
 import runrush.be.runningrecord.dto.RunningRecordRequest;
@@ -21,8 +23,9 @@ public class RunningRecordController {
 
     @PostMapping
     public ResponseEntity<Void> createRunningRecord(@AuthenticationPrincipal UserPrincipal user,
-                                                    @RequestBody RunningRecordRequest request) {
-        runningRecordService.saveRunningRecord(request, user.getId());
+                                                    @RequestPart("image") MultipartFile image,
+                                                    @RequestPart("data") RunningRecordRequest request) {
+        runningRecordService.saveRunningRecord(request, user.getId(), image);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
+++ b/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
@@ -6,12 +6,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import runrush.be.kakao.client.KakaoMapApiClient;
 import runrush.be.runningrecord.domain.RunningRecord;
 import runrush.be.runningrecord.dto.RunningRecordListResponse;
 import runrush.be.runningrecord.dto.RunningRecordRequest;
 import runrush.be.runningrecord.dto.RunningRecordResponse;
 import runrush.be.runningrecord.repository.RunningRecordRepository;
+import runrush.be.s3.service.ImageUploadService;
 import runrush.be.user.domain.User;
 import runrush.be.user.service.UserService;
 
@@ -27,10 +29,13 @@ public class RunningRecordService {
     private final RunningRecordRepository runningRecordRepository;
     private final UserService userService;
     private final KakaoMapApiClient kakaoMapApiClient;
+    private final ImageUploadService imageUploadService;
 
     @Transactional
-    public void saveRunningRecord(RunningRecordRequest request, Long userId) {
+    public void saveRunningRecord(RunningRecordRequest request, Long userId, MultipartFile image) {
         User user = userService.findUserById(userId);
+
+        String imageUrl = imageUploadService.uploadImage(image, "running-record");
 
         double totalDistance = calculateTotalDistance(request.pathGeoJson());
         long totalTime = Duration.between(request.startedTime(), request.endedTime()).getSeconds();
@@ -51,6 +56,7 @@ public class RunningRecordService {
 
         RunningRecord runningRecord = RunningRecord.builder()
                 .user(user)
+                .imageUrl(imageUrl)
                 .pathGeoJson(request.pathGeoJson())
                 .totalDistance(totalDistance)
                 .startLatitude(request.startLatitude())

--- a/src/main/java/runrush/be/s3/service/ImageUploadService.java
+++ b/src/main/java/runrush/be/s3/service/ImageUploadService.java
@@ -1,0 +1,90 @@
+package runrush.be.s3.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ImageUploadService {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png", "gif");
+
+    public String uploadImage(MultipartFile file, String directory) {
+        validateFile(file);
+
+        String fileName = generateFileName(file.getOriginalFilename());
+        String key = buildS3Key(directory, fileName);
+
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .acl("public-read")
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(request, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+            String imageUrl = s3Client.utilities().getUrl(GetUrlRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build()).toExternalForm();
+
+            log.info("이미지 업로드 성공: {}", imageUrl);
+            return imageUrl;
+
+        } catch (IOException e) {
+            log.error("파일 읽기 실패", e);
+            throw new RuntimeException("파일 업로드 중 오류가 발생했습니다.", e);
+        } catch (S3Exception e) {
+            log.error("S3 업로드 실패", e);
+            throw new RuntimeException("S3 업로드에 실패했습니다: " + e.awsErrorDetails().errorMessage(), e);
+        }
+
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 존재하지 않습니다.");
+        }
+
+        String fileName = file.getOriginalFilename();
+        if (fileName == null || !fileName.contains(".") || !hasValidExtension(fileName)) {
+            throw new IllegalArgumentException("지원하지 않는 파일 형식입니다. (jpg, jpeg, png, gif)");
+        }
+    }
+
+    private boolean hasValidExtension(String fileName) {
+        String ext = fileName.substring(fileName.lastIndexOf(".") + 1).toLowerCase();
+        return ALLOWED_EXTENSIONS.contains(ext);
+    }
+
+    private String generateFileName(String fileName) {
+        String substring = fileName.substring(fileName.lastIndexOf("."));
+        return UUID.randomUUID() + "_" + System.currentTimeMillis() + substring;
+    }
+
+    private String buildS3Key(String directory, String fileName) {
+        String datePath = LocalDate.now().toString();
+        return directory + "/" + datePath + "/" + fileName;
+    }
+}


### PR DESCRIPTION
### ✨ 작업 내용
- AWS S3 연동을 위한 SDK 의존성을 추가하고 S3Client를 빈으로 등록하여 이미지 업로드 기능을 구현했습니다.  
- `ImageUploadService`를 통해 확장자 검증, UUID 기반 파일명 생성, 디렉토리 구조화 등 안정적인 이미지 업로드를 지원합니다.
- 러닝 기록 등록 시 이미지 파일과 메타데이터를 `multipart/form-data`로 함께 전송 가능하도록 `@RequestPart` 기반 API로 수정하였습니다.
- 업로드된 이미지는 S3의 `running-record` 디렉토리에 저장되며, 반환된 URL은 러닝 기록과 함께 DB에 저장됩니다.

### 🎯 관련 이슈
- #29 