### PR TITLE
친구 관계 기능 전반 구현 및 관련 API 추가

### DIFF
--- a/src/main/java/runrush/be/coursebookmark/domain/CourseBookmark.java
+++ b/src/main/java/runrush/be/coursebookmark/domain/CourseBookmark.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import runrush.be.recommendedCourse.domain.RecommendedCourse;
 import runrush.be.user.domain.User;
 
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 @Getter
 @Entity
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "course_bookmark")
 public class CourseBookmark {
     @Id

--- a/src/main/java/runrush/be/courselike/domain/CourseLike.java
+++ b/src/main/java/runrush/be/courselike/domain/CourseLike.java
@@ -10,9 +10,7 @@ import runrush.be.user.domain.User;
 @Getter
 @Entity
 @NoArgsConstructor
-@Table(name = "course_like", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"user_id", "recommended_course_id"})
-})
+@Table(name = "course_like")
 public class CourseLike {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/runrush/be/friends/controller/FriendsController.java
+++ b/src/main/java/runrush/be/friends/controller/FriendsController.java
@@ -1,0 +1,48 @@
+package runrush.be.friends.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import runrush.be.auth.model.UserPrincipal;
+import runrush.be.friends.service.FriendsService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/friends")
+public class FriendsController {
+    private final FriendsService friendsService;
+
+    @PostMapping("/request")
+    public ResponseEntity<Void> sendFriendRequest(
+            @AuthenticationPrincipal UserPrincipal user,
+            @RequestParam Long targetId) {
+        friendsService.sendFriendRequest(user.getId(), targetId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/request/accept/{requesterId}")
+    public ResponseEntity<Void> acceptFriendRequest(
+            @AuthenticationPrincipal UserPrincipal user,
+            @PathVariable Long requesterId) {
+        friendsService.acceptFriendRequest(user.getId(), requesterId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/request/reject/{requesterId}")
+    public ResponseEntity<Void> rejectFriendRequest(
+            @AuthenticationPrincipal UserPrincipal user,
+            @PathVariable Long requesterId) {
+        friendsService.rejectFriendRequest(user.getId(), requesterId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{friendId}")
+    public ResponseEntity<Void> removeFriend(
+            @AuthenticationPrincipal UserPrincipal user,
+            @PathVariable Long friendId) {
+        friendsService.removeFriend(user.getId(), friendId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/runrush/be/friends/controller/FriendsController.java
+++ b/src/main/java/runrush/be/friends/controller/FriendsController.java
@@ -6,7 +6,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import runrush.be.auth.model.UserPrincipal;
+import runrush.be.friends.dto.FriendInfoResponse;
 import runrush.be.friends.service.FriendsService;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -44,5 +47,26 @@ public class FriendsController {
             @PathVariable Long friendId) {
         friendsService.removeFriend(user.getId(), friendId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<FriendInfoResponse>> getMyFriends(
+            @AuthenticationPrincipal UserPrincipal user) {
+        List<FriendInfoResponse> myFriends = friendsService.getMyFriends(user.getId());
+        return ResponseEntity.ok().body(myFriends);
+    }
+
+    @GetMapping("/request/sent")
+    public ResponseEntity<List<FriendInfoResponse>> getSentMyRequests(
+            @AuthenticationPrincipal UserPrincipal user) {
+        List<FriendInfoResponse> sentFriendRequest = friendsService.getSentFriendRequest(user.getId());
+        return ResponseEntity.ok().body(sentFriendRequest);
+    }
+
+    @GetMapping("/request/received")
+    public ResponseEntity<List<FriendInfoResponse>> getReceivedMyRequests(
+            @AuthenticationPrincipal UserPrincipal user) {
+        List<FriendInfoResponse> receivedFriendRequest = friendsService.getReceivedFriendRequest(user.getId());
+        return ResponseEntity.ok().body(receivedFriendRequest);
     }
 }

--- a/src/main/java/runrush/be/friends/domain/FriendStatus.java
+++ b/src/main/java/runrush/be/friends/domain/FriendStatus.java
@@ -1,0 +1,6 @@
+package runrush.be.friends.domain;
+
+public enum FriendStatus {
+    PENDING,
+    ACCEPTED,
+}

--- a/src/main/java/runrush/be/friends/domain/Friends.java
+++ b/src/main/java/runrush/be/friends/domain/Friends.java
@@ -1,0 +1,37 @@
+package runrush.be.friends.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import runrush.be.user.domain.User;
+
+@Entity
+@NoArgsConstructor
+public class Friends {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "requester_id")
+    private User requester;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_id")
+    private User target;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "friend_status")
+    private FriendStatus status;
+
+    @Builder
+    public Friends(User requester, User target) {
+        this.requester = requester;
+        this.target = target;
+        this.status = FriendStatus.PENDING;
+    }
+
+    public void accept() {
+        this.status = FriendStatus.ACCEPTED;
+    }
+}

--- a/src/main/java/runrush/be/friends/domain/Friends.java
+++ b/src/main/java/runrush/be/friends/domain/Friends.java
@@ -2,11 +2,14 @@ package runrush.be.friends.domain;
 
 import jakarta.persistence.*;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import runrush.be.user.domain.User;
 
+@Getter
 @Entity
 @NoArgsConstructor
+@Table(name = "friends")
 public class Friends {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/runrush/be/friends/dto/FriendInfoResponse.java
+++ b/src/main/java/runrush/be/friends/dto/FriendInfoResponse.java
@@ -1,0 +1,8 @@
+package runrush.be.friends.dto;
+
+public record FriendInfoResponse(
+        Long id,
+        String name,
+        String profileImage
+) {
+}

--- a/src/main/java/runrush/be/friends/repository/FriendsRepository.java
+++ b/src/main/java/runrush/be/friends/repository/FriendsRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 @Repository
 public interface FriendsRepository extends JpaRepository<Friends, Long> {
     // 특정 사용자 간의 관계 조회 (한 방향)
-    Optional<Friends> findByRequesterIdAndTargetId(Long requestId, Long targetId);
+    Optional<Friends> findByRequesterIdAndTargetId(Long requesterId, Long targetId);
 
     // 내가 보낸 친구 요청들
     @Query("SELECT f FROM Friends f " +
@@ -33,12 +33,16 @@ public interface FriendsRepository extends JpaRepository<Friends, Long> {
     List<Friends> findMyFriends(@Param("userId") Long userId);
 
     // 친구 요청 거절
-    void deleteFriendsRequest(Long userId, Long friendId);
+    @Modifying
+    @Query("DELETE FROM Friends f WHERE " +
+            "f.requester.id = :userId AND f.target.id = :friendId " +
+            "AND f.status = 'PENDING'")
+    void deleteFriendsRequest(@Param("userId") Long userId, @Param("friendId") Long friendId);
 
     @Modifying
     @Query("DELETE FROM Friends f WHERE " +
             "(f.requester.id = :userId1 AND f.target.id = :userId2) OR " +
             "(f.requester.id = :userId2 AND f.target.id = :userId1)")
     void deleteAllFriends(@Param("userId1") Long userId1,
-                       @Param("userId2") Long userId2);
+                          @Param("userId2") Long userId2);
 }

--- a/src/main/java/runrush/be/friends/repository/FriendsRepository.java
+++ b/src/main/java/runrush/be/friends/repository/FriendsRepository.java
@@ -1,0 +1,44 @@
+package runrush.be.friends.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import runrush.be.friends.domain.Friends;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface FriendsRepository extends JpaRepository<Friends, Long> {
+    // 특정 사용자 간의 관계 조회 (한 방향)
+    Optional<Friends> findByRequesterIdAndTargetId(Long requestId, Long targetId);
+
+    // 내가 보낸 친구 요청들
+    @Query("SELECT f FROM Friends f " +
+            "JOIN FETCH f.target " +
+            "WHERE f.requester.id = :userId AND f.status = 'PENDING'")
+    List<Friends> findFriendsRequest(@Param("userId") Long userId);
+
+
+    @Query("SELECT f FROM Friends f " +
+            "JOIN FETCH f.requester " +
+            "WHERE f.target.id = :userId AND f.status = 'PENDING'")
+    List<Friends> findFriendsTarget(@Param("userId") Long userId);
+
+    @Query("SELECT f FROM Friends f " +
+            "JOIN FETCH f.target " +
+            "WHERE f.requester.id = :userId AND f.status = 'ACCEPTED'")
+    List<Friends> findMyFriends(@Param("userId") Long userId);
+
+    // 친구 요청 거절
+    void deleteFriendsRequest(Long userId, Long friendId);
+
+    @Modifying
+    @Query("DELETE FROM Friends f WHERE " +
+            "(f.requester.id = :userId1 AND f.target.id = :userId2) OR " +
+            "(f.requester.id = :userId2 AND f.target.id = :userId1)")
+    void deleteAllFriends(@Param("userId1") Long userId1,
+                       @Param("userId2") Long userId2);
+}

--- a/src/main/java/runrush/be/friends/service/FriendsService.java
+++ b/src/main/java/runrush/be/friends/service/FriendsService.java
@@ -1,0 +1,91 @@
+package runrush.be.friends.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import runrush.be.friends.domain.FriendStatus;
+import runrush.be.friends.domain.Friends;
+import runrush.be.friends.repository.FriendsRepository;
+import runrush.be.user.domain.User;
+import runrush.be.user.service.UserService;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FriendsService {
+    private final FriendsRepository friendsRepository;
+    private final UserService userService;
+
+    @Transactional
+    public void sendFriendRequest(Long requesterId, Long targetId) {
+        if (requesterId.equals(targetId)) {
+            throw new IllegalArgumentException("자기 자신은 친구 요청을 보낼 수 없습니다.");
+        }
+
+        User targetUser = userService.findUserById(targetId);
+        User requesterUser = userService.findUserById(requesterId);
+
+        if (hasRelation(requesterId, targetId)) {
+            throw new IllegalArgumentException("이미 친구이거나 친구 요청이 존재합니다.");
+        }
+
+        Friends friends = Friends.builder()
+                .requester(requesterUser)
+                .target(targetUser)
+                .build();
+
+        friendsRepository.save(friends);
+        log.info("친구 요청 전송: {} -> {}", requesterId, targetId);
+    }
+
+    @Transactional
+    public void acceptFriendRequest(Long requesterId, Long targetId) {
+        Friends pendingRequest = friendsRepository.findByRequesterIdAndTargetId(requesterId, targetId)
+                .orElseThrow(() -> new IllegalArgumentException("친구 요청을 찾을 수 없습니다."));
+
+        if (pendingRequest.getStatus() != FriendStatus.PENDING) {
+            throw new IllegalArgumentException("대기 중인 친구 요청이 아닙니다.");
+        }
+
+        User target = userService.findUserById(targetId);
+        User requester = userService.findUserById(requesterId);
+
+        friendsRepository.delete(pendingRequest);
+
+        Friends friend1 = Friends.builder()
+                .requester(requester)
+                .target(target)
+                .build();
+        friend1.accept();
+
+        Friends friend2 = Friends.builder()
+                .requester(target)
+                .target(requester)
+                .build();
+        friend2.accept();
+
+        friendsRepository.save(friend1);
+        friendsRepository.save(friend2);
+
+        log.info("친구 요청 수락: {} <-> {}", targetId, requesterId);
+    }
+
+    @Transactional
+    public void rejectFriendRequest(Long requesterId, Long targetId) {
+        Friends pendingRequest = friendsRepository.findByRequesterIdAndTargetId(requesterId, targetId)
+                .orElseThrow(() -> new IllegalArgumentException("친구 요청을 찾을 수 없습니다."));
+
+        if (pendingRequest.getStatus() != FriendStatus.PENDING) {
+            throw new IllegalArgumentException("대기 중인 친구 요청이 아닙니다.");
+        }
+
+        friendsRepository.delete(pendingRequest);
+        log.info("친구 요청 거절: {} -> {}", requesterId, targetId);
+    }
+
+    private boolean hasRelation(Long userId, Long friendId) {
+        return friendsRepository.findByRequesterIdAndTargetId(userId, friendId).isPresent() ||
+                friendsRepository.findByRequesterIdAndTargetId(friendId, userId).isPresent();
+    }
+}

--- a/src/main/java/runrush/be/friends/service/FriendsService.java
+++ b/src/main/java/runrush/be/friends/service/FriendsService.java
@@ -6,9 +6,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import runrush.be.friends.domain.FriendStatus;
 import runrush.be.friends.domain.Friends;
+import runrush.be.friends.dto.FriendInfoResponse;
 import runrush.be.friends.repository.FriendsRepository;
 import runrush.be.user.domain.User;
 import runrush.be.user.service.UserService;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -80,7 +83,7 @@ public class FriendsService {
             throw new IllegalArgumentException("대기 중인 친구 요청이 아닙니다.");
         }
 
-        friendsRepository.delete(pendingRequest);
+        friendsRepository.deleteFriendsRequest(requesterId, targetId);
         log.info("친구 요청 거절: {} -> {}", requesterId, targetId);
     }
 
@@ -96,6 +99,45 @@ public class FriendsService {
 
         friendsRepository.deleteAllFriends(userId, friendId);
         log.info("친구 관계 해제: {} <-> {}", userId, friendId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FriendInfoResponse> getMyFriends(Long userId) {
+        List<Friends> myFriends = friendsRepository.findMyFriends(userId);
+
+        return myFriends.stream()
+                .map(friends -> new FriendInfoResponse(
+                        friends.getTarget().getId(),
+                        friends.getTarget().getName(),
+                        friends.getTarget().getProfileImage()
+                ))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<FriendInfoResponse> getSentFriendRequest(Long userId) {
+        List<Friends> friendsRequest = friendsRepository.findFriendsRequest(userId);
+
+        return friendsRequest.stream()
+                .map(request -> new FriendInfoResponse(
+                        request.getTarget().getId(),
+                        request.getTarget().getName(),
+                        request.getTarget().getProfileImage()
+                ))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<FriendInfoResponse> getReceivedFriendRequest(Long userId) {
+        List<Friends> friendsTarget = friendsRepository.findFriendsTarget(userId);
+
+        return friendsTarget.stream()
+                .map(request -> new FriendInfoResponse(
+                        request.getRequester().getId(),
+                        request.getRequester().getName(),
+                        request.getRequester().getProfileImage()
+                ))
+                .toList();
     }
 
     private boolean hasRelation(Long userId, Long friendId) {

--- a/src/main/java/runrush/be/friends/service/FriendsService.java
+++ b/src/main/java/runrush/be/friends/service/FriendsService.java
@@ -84,6 +84,20 @@ public class FriendsService {
         log.info("친구 요청 거절: {} -> {}", requesterId, targetId);
     }
 
+    @Transactional
+    public void removeFriend(Long userId, Long friendId) {
+        boolean isFriend = friendsRepository.findByRequesterIdAndTargetId(userId, friendId)
+                .map(relation -> relation.getStatus() == FriendStatus.ACCEPTED)
+                .orElse(false);
+
+        if (!isFriend) {
+            throw new IllegalArgumentException("친구 관계가 아닙니다.");
+        }
+
+        friendsRepository.deleteAllFriends(userId, friendId);
+        log.info("친구 관계 해제: {} <-> {}", userId, friendId);
+    }
+
     private boolean hasRelation(Long userId, Long friendId) {
         return friendsRepository.findByRequesterIdAndTargetId(userId, friendId).isPresent() ||
                 friendsRepository.findByRequesterIdAndTargetId(friendId, userId).isPresent();


### PR DESCRIPTION
### ✨ 작업 내용

- 친구 관계를 관리하기 위한 도메인 구현 및 API를 추가하였습니다.
- 친구 요청, 수락, 거절, 삭제 등 친구 상태 전반을 처리하는 비즈니스 로직을 구현하였습니다.
- 친구 상태는 `FriendStatus (PENDING, ACCEPTED 등)` enum을 통해 일관되게 관리되며, 수락 시 양방향 관계로 저장됩니다.
- 요청자와 대상자 기준으로 친구 요청 및 친구 목록을 조회할 수 있는 기능을 제공하며, 관련 DTO(`FriendInfoResponse`)를 통해 필요한 정보만 반환합니다.
- 친구 관계 해제 시 양방향 모두 삭제되도록 처리하였습니다.
- `CourseBookmark` 엔티티에는 북마크 생성일자 자동 설정 기능을 추가하여 유지보수를 간편하게 하였습니다.

> 사용자는 친구 기능을 통해 다른 사용자와 관계를 맺고, 상호 소통 기반 기능 확장(예: 친구 기반 추천, 위치 공유 등)이 가능해집니다.

---

### 🎯 관련 이슈

- #31 