### PR TITLE
러닝 기록 소프트 삭제 및 복구/영구 삭제 기능 구현

### DIFF
--- a/src/main/java/runrush/be/runningrecord/controller/RunningRecordController.java
+++ b/src/main/java/runrush/be/runningrecord/controller/RunningRecordController.java
@@ -61,4 +61,12 @@ public class RunningRecordController {
         runningRecordService.restoreRunningRecord(recordId, user.getId());
         return ResponseEntity.ok().build();
     }
+
+    @DeleteMapping("/permanent/{recordId}")
+    public ResponseEntity<Void> permanentDeleteRunningRecord(
+            @PathVariable Long recordId,
+            @AuthenticationPrincipal UserPrincipal user) {
+        runningRecordService.permanentlyDeleteRecord(recordId, user.getId());
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/runrush/be/runningrecord/controller/RunningRecordController.java
+++ b/src/main/java/runrush/be/runningrecord/controller/RunningRecordController.java
@@ -53,4 +53,12 @@ public class RunningRecordController {
         List<RunningRecordListResponse> deletedRecord = runningRecordService.getDeletedRecord(user.getId());
         return ResponseEntity.ok(deletedRecord);
     }
+
+    @PutMapping("/restore/{recordId}")
+    public ResponseEntity<Void> restoreRunningRecord(
+            @PathVariable Long recordId,
+            @AuthenticationPrincipal UserPrincipal user) {
+        runningRecordService.restoreRunningRecord(recordId, user.getId());
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/runrush/be/runningrecord/controller/RunningRecordController.java
+++ b/src/main/java/runrush/be/runningrecord/controller/RunningRecordController.java
@@ -1,7 +1,6 @@
 package runrush.be.runningrecord.controller;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -47,5 +46,11 @@ public class RunningRecordController {
                                                     @AuthenticationPrincipal UserPrincipal user) {
         runningRecordService.deleteRunningRecord(recordId, user.getId());
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/deleted")
+    public ResponseEntity<List<RunningRecordListResponse>> getDeletedRecords(@AuthenticationPrincipal UserPrincipal user) {
+        List<RunningRecordListResponse> deletedRecord = runningRecordService.getDeletedRecord(user.getId());
+        return ResponseEntity.ok(deletedRecord);
     }
 }

--- a/src/main/java/runrush/be/runningrecord/domain/RunningRecord.java
+++ b/src/main/java/runrush/be/runningrecord/domain/RunningRecord.java
@@ -71,6 +71,9 @@ public class RunningRecord {
     @Column(name = "is_deleted")
     private boolean isDeleted = false;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @Builder
     public RunningRecord(
             User user,
@@ -106,6 +109,12 @@ public class RunningRecord {
 
     public void recordDeleted() {
         this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public void restore() {
+        this.isDeleted = false;
+        this.deletedAt = null;
     }
 
     public boolean isRecordDeleted() {

--- a/src/main/java/runrush/be/runningrecord/repository/RunningRecordRepository.java
+++ b/src/main/java/runrush/be/runningrecord/repository/RunningRecordRepository.java
@@ -12,7 +12,10 @@ import java.util.Optional;
 
 @Repository
 public interface RunningRecordRepository extends JpaRepository<RunningRecord, Long> {
-    Optional<RunningRecord> findByIdAndIsDeletedFalse(Long id);
+    @Query("SELECT rr FROM RunningRecord rr " +
+            "JOIN FETCH rr.user " +
+            "WHERE rr.id = :id AND rr.isDeleted = false")
+    Optional<RunningRecord> findByIdAndIsDeletedFalse(@Param("id") Long id);
 
     List<RunningRecord> findByUserIdAndIsDeletedFalse(Long userId);
 
@@ -34,4 +37,7 @@ public interface RunningRecordRepository extends JpaRepository<RunningRecord, Lo
     List<RunningRecord> findMonthlyRecords(@Param("userId") Long userId,
                                            @Param("year") int year,
                                            @Param("month") int month);
+
+    Optional<RunningRecord> findByIdAndUserIdAndIsDeletedTrue(Long id, Long userId);
+    List<RunningRecord> findByUserIdAndIsDeletedTrue(Long userId);
 }

--- a/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
+++ b/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
@@ -120,6 +120,15 @@ public class RunningRecordService {
         log.info("러닝 기록 삭제 완료: recordId={}", recordId);
     }
 
+    @Transactional
+    public void restoreRunningRecord(Long recordId, Long userId) {
+        RunningRecord record = runningRecordRepository.findByIdAndUserIdAndIsDeletedTrue(recordId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("복구할 수 있는 기록이 없습니다."));
+
+        record.restore();
+        log.info("러닝 기록 복구 완료: recordId={}", recordId);
+    }
+
     private double calculateTotalDistance(String pathGeoJson) {
         try {
             ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
+++ b/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
@@ -129,6 +129,23 @@ public class RunningRecordService {
         log.info("러닝 기록 복구 완료: recordId={}", recordId);
     }
 
+    @Transactional
+    public void permanentlyDeleteRecord(Long recordId, Long userId) {
+        RunningRecord record = runningRecordRepository.findByIdAndUserIdAndIsDeletedTrue(recordId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("영구 삭제할 수 있는 기록이 없습니다."));
+
+        if (record.getImageUrl() != null) {
+            try {
+                imageUploadService.deleteImage(record.getImageUrl());
+            } catch (Exception e) {
+                log.warn("이미지 삭제 중 오류 발생: {}", e.getMessage());
+            }
+        }
+
+        runningRecordRepository.delete(record);
+        log.info("러닝 기록 영구 삭제 완료: recordId={}", recordId);
+    }
+
     private double calculateTotalDistance(String pathGeoJson) {
         try {
             ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
+++ b/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
@@ -88,6 +88,13 @@ public class RunningRecordService {
     }
 
     @Transactional(readOnly = true)
+    public List<RunningRecordListResponse> getDeletedRecord(Long userId) {
+        return runningRecordRepository.findByUserIdAndIsDeletedTrue(userId).stream()
+                .map(RunningRecordListResponse::toRecordListResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
     public List<RunningRecordListResponse> getRunningRecords(Long userId) {
         return runningRecordRepository.findByUserIdAndIsDeletedFalse(userId).stream()
                 .map(RunningRecordListResponse::toRecordListResponse)
@@ -112,7 +119,6 @@ public class RunningRecordService {
         runningRecord.recordDeleted();
         log.info("러닝 기록 삭제 완료: recordId={}", recordId);
     }
-
 
     private double calculateTotalDistance(String pathGeoJson) {
         try {

--- a/src/main/java/runrush/be/s3/service/ImageUploadService.java
+++ b/src/main/java/runrush/be/s3/service/ImageUploadService.java
@@ -7,11 +7,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import java.io.IOException;
+import java.net.URL;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -62,6 +64,31 @@ public class ImageUploadService {
 
     }
 
+    public void deleteImage(String imageUrl) {
+        if (imageUrl == null || imageUrl.trim().isEmpty()) {
+            log.warn("삭제할 이미지 URL이 없습니다.");
+            return;
+        }
+
+        try {
+            String key = extractKeyFromUrl(imageUrl);
+            DeleteObjectRequest request = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(request);
+            log.info("S3 이미지 삭제 성공: {}", imageUrl);
+
+        } catch (IllegalArgumentException e) {
+            log.error("잘못된 이미지 URL: {}", imageUrl, e);
+        } catch (S3Exception e) {
+            log.error("S3 이미지 삭제 실패: {}", imageUrl, e);
+        } catch (Exception e) {
+            log.error("예상치 못한 이미지 삭제 오류: {}", imageUrl, e);
+        }
+    }
+
     private void validateFile(MultipartFile file) {
         if (file == null || file.isEmpty()) {
             throw new IllegalArgumentException("파일이 존재하지 않습니다.");
@@ -86,5 +113,21 @@ public class ImageUploadService {
     private String buildS3Key(String directory, String fileName) {
         String datePath = LocalDate.now().toString();
         return directory + "/" + datePath + "/" + fileName;
+    }
+
+    private String extractKeyFromUrl(String imageUrl) {
+        try {
+            URL url = new URL(imageUrl);
+            String path = url.getPath();
+
+            if (path == null || path.isEmpty()) {
+                throw new IllegalArgumentException("URL 경로가 없습니다.");
+            }
+
+            return path.startsWith("/") ? path.substring(1) : path;
+
+        } catch (Exception e) {
+            throw new IllegalArgumentException("잘못된 이미지 URL 형식입니다: " + imageUrl, e);
+        }
     }
 }


### PR DESCRIPTION
### ✨ 작업 내용
- `RunningRecord` 엔티티에 `deletedAt` 필드를 추가하여 soft delete 시점을 기록하도록 구현하였습니다.
- soft delete된 러닝 기록을 복구할 수 있는 `restore` 메서드를 도입하였으며, `recordDeleted()`에서 삭제 시점을 자동 설정하도록 변경하였습니다.
- soft delete된 기록을 조회할 수 있는 API(`/running-record/deleted`) 및 서비스 메서드를 추가했습니다.
- soft delete된 러닝 기록을 복원하거나 영구 삭제할 수 있는 기능을 각각 API(`/restore`, `/permanent-delete`)로 제공하였습니다.
- 영구 삭제 시에는 S3에 업로드된 이미지도 함께 삭제되도록 로직을 통합하였습니다.
- `findByIdAndIsDeletedFalse` 메서드에 fetch join을 적용해 사용자 정보와 함께 조회 가능하도록 최적화하였습니다.

---

### 🎯 관련 이슈
- #34 