### PR TITLE
친구 요청 응답 DTO 구조 개선 및 역할별 분리

### DIFF
--- a/src/main/java/runrush/be/friends/controller/FriendsController.java
+++ b/src/main/java/runrush/be/friends/controller/FriendsController.java
@@ -6,7 +6,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import runrush.be.auth.model.UserPrincipal;
-import runrush.be.friends.dto.FriendInfoResponse;
+import runrush.be.friends.dto.FriendResponse;
+import runrush.be.friends.dto.ReceivedFriendRequestResponse;
+import runrush.be.friends.dto.SentFriendRequestResponse;
 import runrush.be.friends.service.FriendsService;
 
 import java.util.List;
@@ -50,23 +52,23 @@ public class FriendsController {
     }
 
     @GetMapping
-    public ResponseEntity<List<FriendInfoResponse>> getMyFriends(
+    public ResponseEntity<List<FriendResponse>> getMyFriends(
             @AuthenticationPrincipal UserPrincipal user) {
-        List<FriendInfoResponse> myFriends = friendsService.getMyFriends(user.getId());
+        List<FriendResponse> myFriends = friendsService.getMyFriends(user.getId());
         return ResponseEntity.ok().body(myFriends);
     }
 
     @GetMapping("/request/sent")
-    public ResponseEntity<List<FriendInfoResponse>> getSentMyRequests(
+    public ResponseEntity<List<SentFriendRequestResponse>> getSentMyRequests(
             @AuthenticationPrincipal UserPrincipal user) {
-        List<FriendInfoResponse> sentFriendRequest = friendsService.getSentFriendRequest(user.getId());
+        List<SentFriendRequestResponse> sentFriendRequest = friendsService.getSentFriendRequest(user.getId());
         return ResponseEntity.ok().body(sentFriendRequest);
     }
 
     @GetMapping("/request/received")
-    public ResponseEntity<List<FriendInfoResponse>> getReceivedMyRequests(
+    public ResponseEntity<List<ReceivedFriendRequestResponse>> getReceivedMyRequests(
             @AuthenticationPrincipal UserPrincipal user) {
-        List<FriendInfoResponse> receivedFriendRequest = friendsService.getReceivedFriendRequest(user.getId());
+        List<ReceivedFriendRequestResponse> receivedFriendRequest = friendsService.getReceivedFriendRequest(user.getId());
         return ResponseEntity.ok().body(receivedFriendRequest);
     }
 }

--- a/src/main/java/runrush/be/friends/dto/FriendResponse.java
+++ b/src/main/java/runrush/be/friends/dto/FriendResponse.java
@@ -1,7 +1,7 @@
 package runrush.be.friends.dto;
 
-public record FriendInfoResponse(
-        Long id,
+public record FriendResponse(
+        Long friendId,
         String name,
         String profileImage
 ) {

--- a/src/main/java/runrush/be/friends/dto/ReceivedFriendRequestResponse.java
+++ b/src/main/java/runrush/be/friends/dto/ReceivedFriendRequestResponse.java
@@ -1,0 +1,8 @@
+package runrush.be.friends.dto;
+
+public record ReceivedFriendRequestResponse(
+        Long requesterId,
+        String name,
+        String profileImage
+) {
+}

--- a/src/main/java/runrush/be/friends/dto/SentFriendRequestResponse.java
+++ b/src/main/java/runrush/be/friends/dto/SentFriendRequestResponse.java
@@ -1,0 +1,8 @@
+package runrush.be.friends.dto;
+
+public record SentFriendRequestResponse(
+        Long targetId,
+        String name,
+        String profileImage
+) {
+}

--- a/src/main/java/runrush/be/friends/service/FriendsService.java
+++ b/src/main/java/runrush/be/friends/service/FriendsService.java
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import runrush.be.friends.domain.FriendStatus;
 import runrush.be.friends.domain.Friends;
-import runrush.be.friends.dto.FriendInfoResponse;
+import runrush.be.friends.dto.FriendResponse;
+import runrush.be.friends.dto.ReceivedFriendRequestResponse;
+import runrush.be.friends.dto.SentFriendRequestResponse;
 import runrush.be.friends.repository.FriendsRepository;
 import runrush.be.user.domain.User;
 import runrush.be.user.service.UserService;
@@ -102,11 +104,11 @@ public class FriendsService {
     }
 
     @Transactional(readOnly = true)
-    public List<FriendInfoResponse> getMyFriends(Long userId) {
+    public List<FriendResponse> getMyFriends(Long userId) {
         List<Friends> myFriends = friendsRepository.findMyFriends(userId);
 
         return myFriends.stream()
-                .map(friends -> new FriendInfoResponse(
+                .map(friends -> new FriendResponse(
                         friends.getTarget().getId(),
                         friends.getTarget().getName(),
                         friends.getTarget().getProfileImage()
@@ -115,11 +117,11 @@ public class FriendsService {
     }
 
     @Transactional(readOnly = true)
-    public List<FriendInfoResponse> getSentFriendRequest(Long userId) {
+    public List<SentFriendRequestResponse> getSentFriendRequest(Long userId) {
         List<Friends> friendsRequest = friendsRepository.findFriendsRequest(userId);
 
         return friendsRequest.stream()
-                .map(request -> new FriendInfoResponse(
+                .map(request -> new SentFriendRequestResponse(
                         request.getTarget().getId(),
                         request.getTarget().getName(),
                         request.getTarget().getProfileImage()
@@ -128,11 +130,11 @@ public class FriendsService {
     }
 
     @Transactional(readOnly = true)
-    public List<FriendInfoResponse> getReceivedFriendRequest(Long userId) {
+    public List<ReceivedFriendRequestResponse> getReceivedFriendRequest(Long userId) {
         List<Friends> friendsTarget = friendsRepository.findFriendsTarget(userId);
 
         return friendsTarget.stream()
-                .map(request -> new FriendInfoResponse(
+                .map(request -> new ReceivedFriendRequestResponse(
                         request.getRequester().getId(),
                         request.getRequester().getName(),
                         request.getRequester().getProfileImage()


### PR DESCRIPTION
### ✨ 작업 내용

- 친구 요청 목록 응답을 위한 DTO를 역할별로 분리하여 응답 구조를 명확히 하였습니다.
  - 보낸 요청: `SentFriendRequestResponse`
  - 받은 요청: `ReceivedFriendRequestResponse`
- 기존의 `FriendInfoResponse` 클래스를 `FriendResponse`로 클래스명을 변경하여 명확성과 일관성을 확보하였습니다.
- 친구 관련 API 응답에 역할에 따른 DTO를 적용하여 프론트엔드에서 보다 직관적으로 데이터를 처리할 수 있도록 개선하였습니다.

---

### 🎯 관련 이슈
- #36 