### PR TITLE
사용자 닉네임 및 프로필 수정 기능 구현 및 추천 코스 삭제 수정

### DIFF
--- a/src/main/java/runrush/be/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/runrush/be/auth/oauth2/service/CustomOAuth2UserService.java
@@ -15,6 +15,7 @@ import runrush.be.user.domain.User;
 import runrush.be.user.repository.UserRepository;
 
 import java.util.Map;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -41,11 +42,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         User user = userRepository.findByKakaoId(userInfo.getId())
                 .orElseGet(() -> {
+                    String randomNickname = generateUniqueNickname();
                     User newUser = User.builder()
                             .kakaoId(userInfo.getId())
                             .email(userInfo.getEmail())
                             .name(userInfo.getName())
                             .profileImage(userInfo.getImage())
+                            .nickname(randomNickname)
                             .build();
                     return userRepository.save(newUser);
                 });
@@ -53,5 +56,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         log.info("카카오 로그인 성공: 사용자 ID = {}, 이메일 = {}", user.getId(), email);
 
         return UserPrincipal.create(user, attributes);
+    }
+
+    private String generateUniqueNickname() {
+        String nickname;
+        do {
+            nickname = UUID.randomUUID().toString().substring(0, 8);
+        } while (userRepository.existsByNickname(nickname));
+        return nickname;
     }
 }

--- a/src/main/java/runrush/be/coursebookmark/repository/CourseBookmarkRepository.java
+++ b/src/main/java/runrush/be/coursebookmark/repository/CourseBookmarkRepository.java
@@ -1,6 +1,7 @@
 package runrush.be.coursebookmark.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -19,7 +20,9 @@ public interface CourseBookmarkRepository extends JpaRepository<CourseBookmark, 
             "ORDER BY cb.bookmarkedAt DESC")
     List<CourseBookmark> findWithCourseByUserId(Long userId);
 
-    void deleteByRecommendedCourseId(Long recommendedCourseId);
+    @Modifying
+    @Query("DELETE FROM CourseBookmark cb WHERE cb.recommendedCourse.id = :courseId")
+    void deleteByRecommendedCourseId(@Param("courseId") Long courseId);
 
     @Query("SELECT cb.recommendedCourse.id FROM CourseBookmark cb " +
             "WHERE cb.user.id = :userId")

--- a/src/main/java/runrush/be/courselike/repository/CourseLikeRepository.java
+++ b/src/main/java/runrush/be/courselike/repository/CourseLikeRepository.java
@@ -1,6 +1,7 @@
 package runrush.be.courselike.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -18,4 +19,8 @@ public interface CourseLikeRepository extends JpaRepository<CourseLike, Long> {
     long countByRecommendedCourseId(Long courseId);
 
     boolean existsByUserIdAndRecommendedCourseId(Long userId, Long courseId);
+
+    @Modifying
+    @Query("DELETE FROM CourseLike l WHERE l.recommendedCourse.id = :courseId")
+    void deleteByRecommendedCourseId(@Param("courseId") Long courseId);
 }

--- a/src/main/java/runrush/be/recommendedCourse/service/RecommendedCourseService.java
+++ b/src/main/java/runrush/be/recommendedCourse/service/RecommendedCourseService.java
@@ -77,7 +77,7 @@ public class RecommendedCourseService {
             throw new IllegalArgumentException("등록한 사용자만 삭제 가능합니다.");
         }
 
-
+        courseLikeRepository.deleteByRecommendedCourseId(recommendedCourse.getId());
         courseBookmarkRepository.deleteByRecommendedCourseId(recommendedCourse.getId());
         recommendedCourseRepository.delete(recommendedCourse);
     }

--- a/src/main/java/runrush/be/user/controller/UserController.java
+++ b/src/main/java/runrush/be/user/controller/UserController.java
@@ -3,13 +3,14 @@ package runrush.be.user.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import runrush.be.auth.model.UserPrincipal;
 import runrush.be.user.domain.User;
 import runrush.be.user.dto.UserInfoResponse;
+import runrush.be.user.dto.UserUpdateRequest;
 import runrush.be.user.service.UserService;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/user")
@@ -19,12 +20,36 @@ public class UserController {
 
     @GetMapping
     public ResponseEntity<UserInfoResponse> getUserInfo(@AuthenticationPrincipal UserPrincipal user) {
-        if(user == null) {
+        if (user == null) {
             return ResponseEntity.status(401).build();
         }
 
         User userByEmail = userService.findUserById(user.getId());
         UserInfoResponse userInfoResponse = UserInfoResponse.fromEntity(userByEmail);
         return ResponseEntity.ok(userInfoResponse);
+    }
+
+    @GetMapping("/check-nickname")
+    public ResponseEntity<Map<String, Object>> checkNickname(@RequestParam String nickname) {
+        boolean isAvailable = userService.isNicknameAvailable(nickname);
+
+        if (isAvailable) {
+            return ResponseEntity.ok(Map.of(
+                    "available", true,
+                    "message", "사용 가능한 닉네임입니다."
+            ));
+        } else {
+            return ResponseEntity.status(409).body(Map.of(
+                    "available", false,
+                    "message", "이미 사용 중인 닉네임입니다."
+            ));
+        }
+    }
+
+    @PatchMapping("/update")
+    public ResponseEntity<Void> updateProfile(@AuthenticationPrincipal UserPrincipal user,
+                                              @RequestBody UserUpdateRequest request) {
+        userService.updateUserProfile(user.getId(), request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/runrush/be/user/domain/User.java
+++ b/src/main/java/runrush/be/user/domain/User.java
@@ -52,4 +52,8 @@ public class User {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
 }

--- a/src/main/java/runrush/be/user/domain/User.java
+++ b/src/main/java/runrush/be/user/domain/User.java
@@ -25,17 +25,21 @@ public class User {
     @Column(name = "profile_image")
     private String profileImage;
 
+    @Column(unique = true)
+    private String nickname;
+
     @Enumerated(EnumType.STRING)
     private Level level;
 
     private int experiencePoints;
 
     @Builder
-    public User(String kakaoId, String email, String name, String profileImage) {
+    public User(String kakaoId, String email, String name, String profileImage, String nickname) {
         this.kakaoId = kakaoId;
         this.email = email;
         this.name = name;
         this.profileImage = profileImage;
+        this.nickname = nickname;
         this.level = Level.BEGINNER;
         this.experiencePoints = 0;
     }
@@ -43,5 +47,9 @@ public class User {
     public void addExperiencePoints(int points) {
         this.experiencePoints += points;
         this.level = Level.fromExperiencePoints(experiencePoints);
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/runrush/be/user/dto/UserInfoResponse.java
+++ b/src/main/java/runrush/be/user/dto/UserInfoResponse.java
@@ -8,6 +8,7 @@ public record UserInfoResponse(
         String email,
         String name,
         String profileImage,
+        String nickname,
         Level level,
         int experiencePoints
 ) {
@@ -17,6 +18,7 @@ public record UserInfoResponse(
                 user.getEmail(),
                 user.getName(),
                 user.getProfileImage(),
+                user.getNickname(),
                 user.getLevel(),
                 user.getExperiencePoints()
         );

--- a/src/main/java/runrush/be/user/dto/UserUpdateRequest.java
+++ b/src/main/java/runrush/be/user/dto/UserUpdateRequest.java
@@ -1,0 +1,7 @@
+package runrush.be.user.dto;
+
+public record UserUpdateRequest(
+        String nickname,
+        String profileImage
+) {
+}

--- a/src/main/java/runrush/be/user/repository/UserRepository.java
+++ b/src/main/java/runrush/be/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByKakaoId(String kakaoId);
 
     Optional<User> findByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/runrush/be/user/service/UserService.java
+++ b/src/main/java/runrush/be/user/service/UserService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import runrush.be.user.domain.User;
+import runrush.be.user.dto.UserUpdateRequest;
 import runrush.be.user.repository.UserRepository;
 
 @Service
@@ -22,4 +23,26 @@ public class UserService {
         return userRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. ID=" + id));
     }
+
+    @Transactional(readOnly = true)
+    public boolean isNicknameAvailable(String nickname) {
+        return !userRepository.existsByNickname(nickname);
+    }
+
+    @Transactional
+    public void updateUserProfile(Long userId, UserUpdateRequest request) {
+        User user = findUserById(userId);
+
+        if (request.nickname() != null && !user.getNickname().equals(request.nickname())) {
+            if (userRepository.existsByNickname(request.nickname())) {
+                throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+            }
+            user.updateNickname(request.nickname());
+        }
+
+        if (request.profileImage() != null) {
+            user.updateProfileImage(request.profileImage());
+        }
+    }
+
 }


### PR DESCRIPTION
### ✨ 작업 내용
- `User` 엔티티에 `nickname` 필드를 추가하고, 고유 제약 조건(`@Column(unique = true)`)을 설정하여 사용자 구별이 가능하도록 구현하였습니다.
- 사용자의 닉네임 및 프로필 이미지를 수정할 수 있는 `updateNickname`, `updateProfileImage` 메서드를 추가하였습니다.
- 신규 카카오 사용자 가입 시 UUID 기반의 랜덤 닉네임이 자동 생성되며, 중복 여부는 `existsByNickname`으로 확인합니다.
- 사용자 정보 수정을 위한 `UserUpdateRequest` DTO와, 닉네임 정보를 포함한 `UserInfoResponse` DTO를 각각 정의하였습니다.
- 닉네임 중복 확인 API 및 사용자 프로필 수정 API를 추가하여 클라이언트에서 사용자 정보 관리가 가능해졌습니다.
- 그 외 추천 코스 삭제 시 관련 좋아요 및 즐겨찾기까지 함께 삭제되도록 쿼리 수정 및 예외 상황을 보완하였습니다.

---

### 🎯 관련 이슈
- #38 
