### PR TITLE
예외 처리 및 GeoJSON 확장 리팩토링

### DIFF
--- a/src/main/java/runrush/be/auth/controller/AuthController.java
+++ b/src/main/java/runrush/be/auth/controller/AuthController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 import runrush.be.auth.domain.RefreshToken;
 import runrush.be.auth.service.AuthService;
 import runrush.be.auth.service.RefreshTokenService;
+import runrush.be.common.exception.BusinessException;
+import runrush.be.common.exception.ErrorCode;
 
 import java.time.Instant;
 import java.util.Map;
@@ -54,10 +56,10 @@ public class AuthController {
         String refreshToken = getRefreshTokenFromCookie(request);
 
         RefreshToken token = refreshTokenService.findByToken(refreshToken)
-                .orElseThrow(() -> new RuntimeException("유효하지 않은 리프레시 토큰입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_EXPIRED, "유효하지 않은 리프레시 토큰입니다."));
 
         if (token.getExpiresAt().isBefore(Instant.now())) {
-            throw new RuntimeException("리프레시 토큰이 만료되었습니다.");
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_EXPIRED, "리프레시 토큰이 만료되었습니다.");
         }
 
         String accessToken = authService.generateAccessToken(token.getUserEmail());
@@ -78,6 +80,6 @@ public class AuthController {
                 }
             }
         }
-        throw new RuntimeException("리프레시 토큰이 쿠키에 존재하지 않습니다.");
+        throw new BusinessException(ErrorCode.TOKEN_NOT_PROVIDED, "리프레시 토큰이 쿠키에 존재하지 않습니다.");
     }
 }

--- a/src/main/java/runrush/be/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/runrush/be/auth/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package runrush.be.auth.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,6 +14,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import runrush.be.auth.model.UserPrincipal;
+import runrush.be.common.exception.BusinessException;
+import runrush.be.common.exception.ErrorCode;
+import runrush.be.common.exception.ErrorResponse;
 import runrush.be.user.domain.User;
 import runrush.be.user.repository.UserRepository;
 
@@ -26,9 +30,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String token = extractToken(request);
 
         if (token != null) {
@@ -47,13 +57,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
+            } catch (BusinessException e) {
+                log.warn("JWT 인증 실패: 코드={}, 메시지={}", e.getErrorCode().getCode(), e.getMessage());
+                handleJwtError(response, e.getErrorCode(), request);
+                return;
             } catch (Exception e) {
-                log.error("JWT 인증 처리 중 오류 발생: {}", e.getMessage());
-                SecurityContextHolder.clearContext();
-
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.setContentType("application/json;charset=UTF-8");
-                response.getWriter().write("{\"message\": \"토큰이 유효하지 않거나 만료되었습니다.\"}");
+                log.error("JWT 인증 처리 중 예상치 못한 오류 발생: {}", e.getMessage());
+                handleJwtError(response, ErrorCode.INVALID_TOKEN, request);
                 return;
             }
         }
@@ -66,5 +76,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return bearerToken.substring(7);
         }
         return null;
+    }
+
+    private void handleJwtError(HttpServletResponse response, ErrorCode errorCode, HttpServletRequest request) throws IOException {
+        SecurityContextHolder.clearContext();
+
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.ofWithPath(errorCode, request.getRequestURI());
+        String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+
+        response.getWriter().write(jsonResponse);
     }
 }

--- a/src/main/java/runrush/be/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/runrush/be/auth/jwt/JwtTokenProvider.java
@@ -1,12 +1,14 @@
 package runrush.be.auth.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import runrush.be.common.exception.BusinessException;
+import runrush.be.common.exception.ErrorCode;
 import runrush.be.user.domain.User;
 import runrush.be.user.repository.UserRepository;
 
@@ -38,7 +40,7 @@ public class JwtTokenProvider {
 
     public String generateAccessToken(String email) {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: "+ email));
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + email));
 
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + jwtAccessTokenExpiration);
@@ -47,6 +49,7 @@ public class JwtTokenProvider {
                 .subject(email)
                 .claim("userId", user.getId())
                 .claim("name", user.getName())
+                .claim("type", "access")
                 .issuedAt(now)
                 .expiration(expiryDate)
                 .signWith(getSigningKey())
@@ -59,6 +62,7 @@ public class JwtTokenProvider {
 
         return Jwts.builder()
                 .subject(email)
+                .claim("type", "refresh")
                 .issuedAt(now)
                 .expiration(expiryDate)
                 .signWith(getSigningKey())
@@ -66,11 +70,33 @@ public class JwtTokenProvider {
     }
 
     private Claims parseClaims(String token) {
-        return Jwts.parser()
-                .verifyWith(getSigningKey())
-                .build()
-                .parseSignedClaims(token)
-                .getPayload();
+        try {
+            return Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰이라도 클레임은 읽을 수 있음 (토큰 타입 확인용)
+            String tokenType = getTokenTypeFromExpiredToken(e);
+            if ("refresh".equals(tokenType)) {
+                throw new BusinessException(ErrorCode.REFRESH_TOKEN_EXPIRED);
+            } else {
+                throw new BusinessException(ErrorCode.ACCESS_TOKEN_EXPIRED);
+            }
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT 토큰: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.UNSUPPORTED_TOKEN);
+        } catch (MalformedJwtException e) {
+            log.warn("잘못된 형식의 JWT 토큰: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.MALFORMED_TOKEN);
+        } catch (SignatureException e) {
+            log.warn("JWT 서명이 유효하지 않음: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.TOKEN_SIGNATURE_INVALID);
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT 토큰이 비어있거나 null: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
     }
 
     public String getEmailFromToken(String token) {
@@ -99,8 +125,17 @@ public class JwtTokenProvider {
                     .parseSignedClaims(token);
             return true;
         } catch (Exception e) {
-            log.warn("토큰 검증 실패: {}", e.getMessage());
-            return false;
+            log.warn("예상치 못한 토큰 검증 오류: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    private String getTokenTypeFromExpiredToken(ExpiredJwtException e) {
+        try {
+            return e.getClaims().get("tokenType", String.class);
+        } catch (Exception ex) {
+            log.warn("만료된 토큰에서 타입을 읽을 수 없음: {}", ex.getMessage());
+            return "access";
         }
     }
 }

--- a/src/main/java/runrush/be/auth/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/runrush/be/auth/oauth2/OAuth2LoginSuccessHandler.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 import runrush.be.auth.model.UserPrincipal;
 import runrush.be.auth.service.AuthService;
+import runrush.be.common.exception.BusinessException;
 
 import java.io.IOException;
 
@@ -43,13 +44,22 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
             log.info("OAuth2 로그인 성공 - 리다이렉트: {}", targetUrl);
 
+        } catch (BusinessException e) {
+            log.error("OAuth2 로그인 처리 중 비즈니스 예외 발생: 코드={}, 메시지={}", e.getErrorCode().getCode(), e.getMessage());
+            handleAuthenticationError(response, "비즈니스 로직 오류");
         } catch (Exception e) {
-            log.error("OAuth2 로그인 처리 중 오류 발생", e);
-            String errorUrl = UriComponentsBuilder.fromUriString(redirectUri)
-                    .queryParam("success", false)
-                    .build().toUriString();
-
-            response.sendRedirect(errorUrl);
+            log.error("OAuth2 로그인 처리 중 예상치 못한 오류 발생", e);
+            handleAuthenticationError(response, "로그인 처리 중 오류");
         }
+    }
+
+    private void handleAuthenticationError(HttpServletResponse response, String errorReason) throws IOException {
+        String errorUrl = UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("success", false)
+                .queryParam("error", errorReason)
+                .build().toUriString();
+
+        response.sendRedirect(errorUrl);
+        log.info("OAuth2 로그인 실패 - 에러 리다이렉트: {}", errorUrl);
     }
 }

--- a/src/main/java/runrush/be/auth/service/AuthService.java
+++ b/src/main/java/runrush/be/auth/service/AuthService.java
@@ -5,6 +5,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import runrush.be.auth.jwt.JwtTokenProvider;
+import runrush.be.common.exception.BusinessException;
+import runrush.be.common.exception.ErrorCode;
 
 import java.time.Instant;
 
@@ -16,13 +18,13 @@ public class AuthService {
 
     public void logout(String accessToken, HttpServletResponse response) {
         if (accessToken == null || !accessToken.startsWith("Bearer ")) {
-            throw new IllegalArgumentException("유효한 토큰 형식이 아닙니다.");
+            throw new BusinessException(ErrorCode.INVALID_TOKEN, "유효한 토큰 형식이 아닙니다.");
         }
 
         String token = accessToken.substring(7);
 
         if (!jwtTokenProvider.validateToken(token)) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
         }
 
         String email = jwtTokenProvider.getEmailFromToken(token);

--- a/src/main/java/runrush/be/auth/service/RefreshTokenService.java
+++ b/src/main/java/runrush/be/auth/service/RefreshTokenService.java
@@ -6,6 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import runrush.be.auth.domain.RefreshToken;
 import runrush.be.auth.jwt.JwtTokenProvider;
 import runrush.be.auth.repository.RefreshTokenRepository;
+import runrush.be.common.exception.BusinessException;
+import runrush.be.common.exception.ErrorCode;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -52,12 +54,12 @@ public class RefreshTokenService {
     private void verifyExpiration(RefreshToken token) {
         if (token.getExpiresAt().compareTo(Instant.now()) < 0) {
             refreshTokenRepository.delete(token);
-            throw new RuntimeException("리프레시 토큰이 만료되었습니다. 다시 로그인해주세요");
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_EXPIRED, "리프레시 토큰이 만료되었습니다. 다시 로그인해주세요.");
         }
 
         if(!jwtTokenProvider.validateToken(token.getToken())) {
             refreshTokenRepository.delete(token);
-            throw new RuntimeException("리프레시 토큰이 유효하지 않습니다. 다시 로그인해주세요.");
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_EXPIRED, "리프레시 토큰이 유효하지 않습니다. 다시 로그인해주세요.");
         }
     }
 }

--- a/src/main/java/runrush/be/common/exception/BusinessException.java
+++ b/src/main/java/runrush/be/common/exception/BusinessException.java
@@ -1,0 +1,23 @@
+package runrush.be.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String customMessage, Throwable cause) {
+        super(customMessage, cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/runrush/be/common/exception/ErrorCode.java
+++ b/src/main/java/runrush/be/common/exception/ErrorCode.java
@@ -1,0 +1,76 @@
+package runrush.be.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    // ===== 공통 에러 (C: Common) =====
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "C001", "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "C002", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "C003", "권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "C004", "요청한 리소스를 찾을 수 없습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C005", "허용되지 않은 HTTP 메서드입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C006", "서버 내부 오류가 발생했습니다."),
+
+    // ===== 사용자 관련 에러 (U: User) =====
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "U002", "이미 존재하는 사용자입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "U003", "비밀번호가 올바르지 않습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "U004", "이미 사용 중인 이메일입니다."),
+    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "U005", "올바르지 않은 이메일 형식입니다."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "U006", "비밀번호가 일치하지 않습니다."),
+    USER_DEACTIVATED(HttpStatus.FORBIDDEN, "U007", "비활성화된 사용자입니다."),
+
+    // ===== JWT 관련 에러 (J: JWT) =====
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "J001", "Access Token이 만료되었습니다. /auth/token 호출로 새 accessToken을 발급받아 원래 요청을 재시도하세요."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "J002", "Refresh Token이 만료되었습니다. 사용자 로그아웃 후 로그인 페이지로 리디렉션하세요."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "J003", "유효하지 않은 토큰입니다. 로그인 필요 및 로그인 페이지로 이동하세요."),
+    TOKEN_NOT_PROVIDED(HttpStatus.UNAUTHORIZED, "J004", "토큰이 제공되지 않았습니다."),
+    MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "J005", "토큰 형식이 올바르지 않습니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "J006", "지원되지 않는 토큰입니다."),
+    TOKEN_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "J007", "토큰 서명이 유효하지 않습니다."),
+
+    // ===== 친구 관련 에러 (F: Friends) =====
+    FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "친구 요청을 찾을 수 없습니다."),
+    FRIEND_REQUEST_ALREADY_EXISTS(HttpStatus.CONFLICT, "F002", "이미 친구 요청이 존재합니다."),
+    CANNOT_ADD_SELF_AS_FRIEND(HttpStatus.BAD_REQUEST, "F003", "자기 자신을 친구로 추가할 수 없습니다."),
+    ALREADY_FRIENDS(HttpStatus.CONFLICT, "F004", "이미 친구 관계입니다."),
+    FRIEND_REQUEST_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "F005", "이미 처리된 친구 요청입니다."),
+
+    // ===== 게시글 관련 에러 (P: Post) =====
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "게시글을 찾을 수 없습니다."),
+    POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "P002", "게시글에 접근할 권한이 없습니다."),
+    POST_TITLE_REQUIRED(HttpStatus.BAD_REQUEST, "P003", "게시글 제목은 필수입니다."),
+    POST_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "P004", "게시글 내용은 필수입니다."),
+    POST_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "P005", "게시글 제목이 너무 깁니다."),
+
+    // ===== 댓글 관련 에러 (CM: Comment) =====
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM001", "댓글을 찾을 수 없습니다."),
+    COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "CM002", "댓글에 접근할 권한이 없습니다."),
+    COMMENT_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "CM003", "댓글 내용은 필수입니다."),
+    COMMENT_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "CM004", "댓글 내용이 너무 깁니다."),
+
+    // ===== 파일 관련 에러 (FL: File) =====
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "FL001", "파일을 찾을 수 없습니다."),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FL002", "파일 업로드에 실패했습니다."),
+    INVALID_FILE_FORMAT(HttpStatus.BAD_REQUEST, "FL003", "지원하지 않는 파일 형식입니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "FL004", "파일 크기가 제한을 초과했습니다."),
+
+    // ===== 인증/인가 관련 에러 (A: Auth) =====
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "A001", "로그인에 실패했습니다."),
+    ACCOUNT_LOCKED(HttpStatus.LOCKED, "A002", "계정이 잠겨있습니다."),
+    TOO_MANY_LOGIN_ATTEMPTS(HttpStatus.TOO_MANY_REQUESTS, "A003", "로그인 시도 횟수를 초과했습니다."),
+    EMAIL_VERIFICATION_REQUIRED(HttpStatus.FORBIDDEN, "A004", "이메일 인증이 필요합니다."),
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "A005", "유효하지 않은 인증 코드입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/runrush/be/common/exception/ErrorResponse.java
+++ b/src/main/java/runrush/be/common/exception/ErrorResponse.java
@@ -1,0 +1,51 @@
+package runrush.be.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ErrorResponse (
+    String code,
+    String message,
+    LocalDateTime timestamp,
+    String path
+)
+
+    {
+        public static ErrorResponse of (ErrorCode errorCode){
+        return new ErrorResponse(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                LocalDateTime.now(),
+                null
+        );
+    }
+
+        public static ErrorResponse ofWithCustomMessage (ErrorCode errorCode, String customMessage){
+        return new ErrorResponse(
+                errorCode.getCode(),
+                customMessage,
+                LocalDateTime.now(),
+                null
+        );
+    }
+
+        public static ErrorResponse ofWithPath (ErrorCode errorCode, String path){
+        return new ErrorResponse(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                LocalDateTime.now(),
+                path
+        );
+    }
+
+        public static ErrorResponse ofWithCustomMessageAndPath (ErrorCode errorCode, String customMessage, String path){
+        return new ErrorResponse(
+                errorCode.getCode(),
+                customMessage,
+                LocalDateTime.now(),
+                path
+        );
+    }
+    }

--- a/src/main/java/runrush/be/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/runrush/be/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,147 @@
+package runrush.be.common.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    /**
+     * 비즈니스 로직에서 발생하는 예외 처리
+     */
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(
+            BusinessException e,
+            HttpServletRequest request) {
+
+        log.warn("비즈니스 예외 발생: code={}, message={}, path={}",
+                e.getErrorCode().getCode(), e.getMessage(), request.getRequestURI());
+
+        ErrorResponse errorResponse = ErrorResponse.ofWithCustomMessageAndPath(
+                e.getErrorCode(),
+                e.getMessage(),
+                request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(errorResponse);
+    }
+
+    /**
+     * 잘못된 타입의 파라미터가 전달된 경우 처리
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e,
+            HttpServletRequest request) {
+
+        String requiredTypeName = e.getRequiredType() != null
+                ? e.getRequiredType().getSimpleName()
+                : "알 수 없음";
+
+        log.warn("파라미터 타입이 일치하지 않습니다: parameter={}, value={}, requiredType={}",
+                e.getName(), e.getValue(), requiredTypeName);
+
+        String errorMessage = String.format("파라미터 '%s'의 값 '%s'이(가) 올바르지 않습니다.",
+                e.getName(), e.getValue());
+
+        ErrorResponse errorResponse = ErrorResponse.ofWithCustomMessageAndPath(
+                ErrorCode.INVALID_REQUEST,
+                errorMessage,
+                request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_REQUEST.getStatus())
+                .body(errorResponse);
+    }
+
+    /**
+     * 지원하지 않는 HTTP 메서드 요청 처리
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException e,
+            HttpServletRequest request) {
+
+        log.warn("지원하지 않는 HTTP 메서드={}, uri={}", request.getMethod(), request.getRequestURI());
+
+        ErrorResponse errorResponse = ErrorResponse.ofWithPath(
+                ErrorCode.METHOD_NOT_ALLOWED,
+                request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(ErrorCode.METHOD_NOT_ALLOWED.getStatus())
+                .body(errorResponse);
+    }
+
+    /**
+     * 요청 본문을 읽을 수 없는 경우 처리 (잘못된 JSON 등)
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException e,
+            HttpServletRequest request) {
+
+        log.warn("요청 본문 읽기 실패: {}", e.getMessage());
+
+        ErrorResponse errorResponse = ErrorResponse.ofWithCustomMessageAndPath(
+                ErrorCode.INVALID_REQUEST,
+                "요청 본문을 읽을 수 없습니다. JSON 형식을 확인해주세요.",
+                request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_REQUEST.getStatus())
+                .body(errorResponse);
+    }
+
+    /**
+     * 404 Not Found 처리 (핸들러를 찾을 수 없는 경우)
+     */
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(
+            NoHandlerFoundException e,
+            HttpServletRequest request) {
+
+        log.warn("핸들러를 찾을 수 없습니다: method={}, uri={}", e.getHttpMethod(), e.getRequestURL());
+
+        ErrorResponse errorResponse = ErrorResponse.ofWithPath(
+                ErrorCode.NOT_FOUND,
+                request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(ErrorCode.NOT_FOUND.getStatus())
+                .body(errorResponse);
+    }
+
+    /**
+     * 예상하지 못한 모든 예외 처리
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(
+            Exception e,
+            HttpServletRequest request) {
+
+        log.error("예상치 못한 예외 발생: ", e);
+
+        ErrorResponse errorResponse = ErrorResponse.ofWithPath(
+                ErrorCode.INTERNAL_SERVER_ERROR,
+                request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(errorResponse);
+    }
+}

--- a/src/main/java/runrush/be/config/SecurityConfig.java
+++ b/src/main/java/runrush/be/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package runrush.be.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -38,6 +39,7 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/oauth2/**", "/login/**", "/auth/token", "/auth/refresh").permitAll()
                         .anyRequest().authenticated()
                 )
@@ -57,7 +59,7 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowCredentials(true);
         configuration.setAllowedOrigins(List.of("http://localhost:5173"));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setExposedHeaders(List.of("Authorization")); // 필요시 추가
 

--- a/src/main/java/runrush/be/coursebookmark/controller/CourseBookmarkController.java
+++ b/src/main/java/runrush/be/coursebookmark/controller/CourseBookmarkController.java
@@ -21,12 +21,12 @@ public class CourseBookmarkController {
     public ResponseEntity<BookmarkToggleResponse> toggleBookmark(@PathVariable Long courseId,
                                                                  @AuthenticationPrincipal UserPrincipal user) {
         BookmarkToggleResponse bookmarkToggleResponse = courseBookmarkService.toggleBookmark(user.getId(), courseId);
-        return ResponseEntity.ok().body(bookmarkToggleResponse);
+        return ResponseEntity.ok(bookmarkToggleResponse);
     }
 
     @GetMapping("/my")
     public ResponseEntity<List<BookmarkedCourseListResponse>> getMyBookmarkedCourses(@AuthenticationPrincipal UserPrincipal user) {
         List<BookmarkedCourseListResponse> bookmarkedCourses = courseBookmarkService.getBookmarkedCourses(user.getId());
-        return ResponseEntity.ok().body(bookmarkedCourses);
+        return ResponseEntity.ok(bookmarkedCourses);
     }
 }

--- a/src/main/java/runrush/be/coursebookmark/service/CourseBookmarkService.java
+++ b/src/main/java/runrush/be/coursebookmark/service/CourseBookmarkService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import runrush.be.common.exception.BusinessException;
+import runrush.be.common.exception.ErrorCode;
 import runrush.be.coursebookmark.domain.CourseBookmark;
 import runrush.be.coursebookmark.dto.BookmarkToggleResponse;
 import runrush.be.coursebookmark.dto.BookmarkedCourseListResponse;
@@ -28,10 +30,10 @@ public class CourseBookmarkService {
     public BookmarkToggleResponse toggleBookmark(Long userId, Long courseId) {
         User user = userService.findUserById(userId);
         RecommendedCourse recommendedCourse = recommendedCourseRepository.findById(courseId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 코스입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND, "존재하지 않는 코스입니다."));
 
         if (recommendedCourse.getUser().getId().equals(user.getId())) {
-            throw new IllegalArgumentException("본인이 등록한 코스는 즐겨찾기 할 수 없습니다.");
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "본인이 등록한 코스는 즐겨찾기 할 수 없습니다.");
         }
 
         Optional<CourseBookmark> existsBookmark = courseBookmarkRepository.findByUserIdAndRecommendedCourseId(userId, courseId);

--- a/src/main/java/runrush/be/courselike/service/CourseLikeService.java
+++ b/src/main/java/runrush/be/courselike/service/CourseLikeService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import runrush.be.common.exception.BusinessException;
+import runrush.be.common.exception.ErrorCode;
 import runrush.be.courselike.domain.CourseLike;
 import runrush.be.courselike.repository.CourseLikeRepository;
 import runrush.be.recommendedCourse.domain.RecommendedCourse;
@@ -26,7 +28,7 @@ public class CourseLikeService {
     public void likeToggle(Long userId, Long courseId) {
         User user = userService.findUserById(userId);
         RecommendedCourse recommendedCourse = recommendedCourseRepository.findById(courseId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 코스입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND, "존재하지 않는 코스입니다."));
 
         Optional<CourseLike> existsLike = courseLikeRepository.findByUserIdAndRecommendedCourseId(userId, courseId);
         if (existsLike.isPresent()) {

--- a/src/main/java/runrush/be/friends/controller/FriendsController.java
+++ b/src/main/java/runrush/be/friends/controller/FriendsController.java
@@ -55,20 +55,20 @@ public class FriendsController {
     public ResponseEntity<List<FriendResponse>> getMyFriends(
             @AuthenticationPrincipal UserPrincipal user) {
         List<FriendResponse> myFriends = friendsService.getMyFriends(user.getId());
-        return ResponseEntity.ok().body(myFriends);
+        return ResponseEntity.ok(myFriends);
     }
 
     @GetMapping("/request/sent")
     public ResponseEntity<List<SentFriendRequestResponse>> getSentMyRequests(
             @AuthenticationPrincipal UserPrincipal user) {
         List<SentFriendRequestResponse> sentFriendRequest = friendsService.getSentFriendRequest(user.getId());
-        return ResponseEntity.ok().body(sentFriendRequest);
+        return ResponseEntity.ok(sentFriendRequest);
     }
 
     @GetMapping("/request/received")
     public ResponseEntity<List<ReceivedFriendRequestResponse>> getReceivedMyRequests(
             @AuthenticationPrincipal UserPrincipal user) {
         List<ReceivedFriendRequestResponse> receivedFriendRequest = friendsService.getReceivedFriendRequest(user.getId());
-        return ResponseEntity.ok().body(receivedFriendRequest);
+        return ResponseEntity.ok(receivedFriendRequest);
     }
 }

--- a/src/main/java/runrush/be/friends/service/FriendsService.java
+++ b/src/main/java/runrush/be/friends/service/FriendsService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import runrush.be.common.exception.BusinessException;
+import runrush.be.common.exception.ErrorCode;
 import runrush.be.friends.domain.FriendStatus;
 import runrush.be.friends.domain.Friends;
 import runrush.be.friends.dto.FriendResponse;
@@ -25,14 +27,14 @@ public class FriendsService {
     @Transactional
     public void sendFriendRequest(Long requesterId, Long targetId) {
         if (requesterId.equals(targetId)) {
-            throw new IllegalArgumentException("자기 자신은 친구 요청을 보낼 수 없습니다.");
+            throw new BusinessException(ErrorCode.CANNOT_ADD_SELF_AS_FRIEND);
         }
 
         User targetUser = userService.findUserById(targetId);
         User requesterUser = userService.findUserById(requesterId);
 
         if (hasRelation(requesterId, targetId)) {
-            throw new IllegalArgumentException("이미 친구이거나 친구 요청이 존재합니다.");
+            throw new BusinessException(ErrorCode.FRIEND_REQUEST_ALREADY_EXISTS);
         }
 
         Friends friends = Friends.builder()
@@ -47,10 +49,10 @@ public class FriendsService {
     @Transactional
     public void acceptFriendRequest(Long requesterId, Long targetId) {
         Friends pendingRequest = friendsRepository.findByRequesterIdAndTargetId(requesterId, targetId)
-                .orElseThrow(() -> new IllegalArgumentException("친구 요청을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.FRIEND_REQUEST_NOT_FOUND));
 
         if (pendingRequest.getStatus() != FriendStatus.PENDING) {
-            throw new IllegalArgumentException("대기 중인 친구 요청이 아닙니다.");
+            throw new BusinessException(ErrorCode.FRIEND_REQUEST_ALREADY_PROCESSED, "대기 중인 친구 요청이 아닙니다.");
         }
 
         User target = userService.findUserById(targetId);
@@ -79,10 +81,10 @@ public class FriendsService {
     @Transactional
     public void rejectFriendRequest(Long requesterId, Long targetId) {
         Friends pendingRequest = friendsRepository.findByRequesterIdAndTargetId(requesterId, targetId)
-                .orElseThrow(() -> new IllegalArgumentException("친구 요청을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.FRIEND_REQUEST_NOT_FOUND));
 
         if (pendingRequest.getStatus() != FriendStatus.PENDING) {
-            throw new IllegalArgumentException("대기 중인 친구 요청이 아닙니다.");
+            throw new BusinessException(ErrorCode.FRIEND_REQUEST_ALREADY_PROCESSED, "대기 중인 친구 요청이 아닙니다.");
         }
 
         friendsRepository.deleteFriendsRequest(requesterId, targetId);
@@ -96,7 +98,7 @@ public class FriendsService {
                 .orElse(false);
 
         if (!isFriend) {
-            throw new IllegalArgumentException("친구 관계가 아닙니다.");
+            throw new BusinessException(ErrorCode.ALREADY_FRIENDS, "친구 관계가 아닙니다.");
         }
 
         friendsRepository.deleteAllFriends(userId, friendId);

--- a/src/main/java/runrush/be/recommendedCourse/controller/RecommendedCourseController.java
+++ b/src/main/java/runrush/be/recommendedCourse/controller/RecommendedCourseController.java
@@ -47,13 +47,13 @@ public class RecommendedCourseController {
     public ResponseEntity<RecommendedCourseResponse> getCourse(@PathVariable Long courseId,
                                                                @AuthenticationPrincipal UserPrincipal user) {
         RecommendedCourseResponse recommendedCourse = recommendedCourseService.getRecommendedCourseDetail(courseId, user.getId());
-        return ResponseEntity.ok().body(recommendedCourse);
+        return ResponseEntity.ok(recommendedCourse);
     }
 
     @GetMapping("/my")
     public ResponseEntity<List<RecommendedCourseMyListResponse>> getMyRecommendedCourses(@AuthenticationPrincipal UserPrincipal user) {
         List<RecommendedCourseMyListResponse> myRecommendedCourses = recommendedCourseService.getMyRecommendedCourses(user.getId());
-        return ResponseEntity.ok().body(myRecommendedCourses);
+        return ResponseEntity.ok(myRecommendedCourses);
     }
 
     @GetMapping
@@ -62,6 +62,6 @@ public class RecommendedCourseController {
             @AuthenticationPrincipal UserPrincipal user
     ) {
         List<RecommendedCourseListResponse> recommendedCourses = recommendedCourseService.getRecommendedCourses(sortType, user.getId());
-        return ResponseEntity.ok().body(recommendedCourses);
+        return ResponseEntity.ok(recommendedCourses);
     }
 }

--- a/src/main/java/runrush/be/recommendedCourse/domain/RecommendedCourse.java
+++ b/src/main/java/runrush/be/recommendedCourse/domain/RecommendedCourse.java
@@ -41,7 +41,7 @@ public class RecommendedCourse {
     private String description;
 
     @Lob
-    @Column(name = "path_geo_json")
+    @Column(name = "path_geo_json", columnDefinition = "LONGTEXT")
     private String pathGeoJson;
 
     @Column(name = "total_distance")

--- a/src/main/java/runrush/be/recommendedCourse/dto/RecommendedCourseResponse.java
+++ b/src/main/java/runrush/be/recommendedCourse/dto/RecommendedCourseResponse.java
@@ -6,6 +6,7 @@ import runrush.be.recommendedCourse.domain.RecommendedCourse;
 
 public record RecommendedCourseResponse(
         Long id,
+        Long userId,
         String userName,
         String title,
         String description,
@@ -23,6 +24,7 @@ public record RecommendedCourseResponse(
                                                              boolean isBookmarked) {
         return new RecommendedCourseResponse(
                 course.getId(),
+                course.getUser().getId(),
                 course.getUser().getName(),
                 course.getTitle(),
                 course.getDescription(),

--- a/src/main/java/runrush/be/recommendedCourse/service/RecommendedCourseService.java
+++ b/src/main/java/runrush/be/recommendedCourse/service/RecommendedCourseService.java
@@ -3,6 +3,8 @@ package runrush.be.recommendedCourse.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import runrush.be.common.exception.BusinessException;
+import runrush.be.common.exception.ErrorCode;
 import runrush.be.coursebookmark.repository.CourseBookmarkRepository;
 import runrush.be.courselike.repository.CourseLikeRepository;
 import runrush.be.recommendedCourse.domain.RecommendedCourse;
@@ -30,7 +32,7 @@ public class RecommendedCourseService {
         RunningRecord runningRecord = runningRecordService.validateRunningRecord(recordId, userId);
 
         if (recommendedCourseRepository.existsBySourceRecordId(recordId)) {
-            throw new IllegalArgumentException("이미 추천된 기록입니다.");
+            throw new BusinessException(ErrorCode.ALREADY_FRIENDS, "이미 추천된 기록입니다.");
         }
 
         String title = name + "님의 추천 코스 #" + recordId;
@@ -56,7 +58,7 @@ public class RecommendedCourseService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 코스입니다."));
 
         if (!(recommendedCourse.getUser().getId().equals(userId))) {
-            throw new IllegalArgumentException("등록한 사용자만 수정이 가능합니다.");
+            throw new BusinessException(ErrorCode.POST_ACCESS_DENIED, "등록한 사용자만 수정이 가능합니다.");
         }
 
         if (request.title() != null && !request.title().isBlank()) {
@@ -71,10 +73,10 @@ public class RecommendedCourseService {
     @Transactional
     public void deleteRecommendedCourse(Long courseId, Long userId) {
         RecommendedCourse recommendedCourse = recommendedCourseRepository.findById(courseId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 코스입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND, "존재하지 않는 코스입니다."));
 
         if (!(recommendedCourse.getUser().getId().equals(userId))) {
-            throw new IllegalArgumentException("등록한 사용자만 삭제 가능합니다.");
+            throw new BusinessException(ErrorCode.POST_ACCESS_DENIED, "등록한 사용자만 삭제 가능합니다.");
         }
 
         courseLikeRepository.deleteByRecommendedCourseId(recommendedCourse.getId());
@@ -85,7 +87,7 @@ public class RecommendedCourseService {
     @Transactional(readOnly = true)
     public RecommendedCourseResponse getRecommendedCourseDetail(Long courseId, Long userId) {
         RecommendedCourse recommendedCourse = recommendedCourseRepository.findByCourseId(courseId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 코스입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND, "존재하지 않는 코스입니다."));
 
         long likeCount = courseLikeRepository.countByRecommendedCourseId(courseId);
         boolean isLiked = courseLikeRepository.existsByUserIdAndRecommendedCourseId(userId, courseId);

--- a/src/main/java/runrush/be/runningrecord/domain/RunningRecord.java
+++ b/src/main/java/runrush/be/runningrecord/domain/RunningRecord.java
@@ -35,7 +35,7 @@ public class RunningRecord {
     private String endLocationName;
 
     @Lob
-    @Column(name = "path_geo_json", columnDefinition = "TEXT")
+    @Column(name = "path_geo_json", columnDefinition = "LONGTEXT")
     private String pathGeoJson;
 
     @Column(name = "total_distance")

--- a/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
+++ b/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import runrush.be.common.exception.BusinessException;
+import runrush.be.common.exception.ErrorCode;
 import runrush.be.kakao.client.KakaoMapApiClient;
 import runrush.be.runningrecord.domain.RunningRecord;
 import runrush.be.runningrecord.dto.RunningRecordListResponse;
@@ -81,7 +83,7 @@ public class RunningRecordService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않거나 삭제된 기록입니다."));
 
         if (!runningRecord.getUser().getEmail().equals(email)) {
-            throw new IllegalArgumentException("본인의 기록만 조회할 수 있습니다.");
+            throw new BusinessException(ErrorCode.POST_ACCESS_DENIED, "본인의 기록만 조회할 수 있습니다.");
         }
 
         return RunningRecordResponse.toRecordResponse(runningRecord);
@@ -107,7 +109,7 @@ public class RunningRecordService {
                 .orElseThrow(() -> new IllegalArgumentException("기록이 존재하지 않거나 삭제되었습니다."));
 
         if (!runningRecord.getUser().getId().equals(userId)) {
-            throw new IllegalArgumentException("본인의 기록만 추천할 수 있습니다.");
+            throw new BusinessException(ErrorCode.POST_ACCESS_DENIED, "본인의 기록만 추천할 수 있습니다.");
         }
 
         return runningRecord;
@@ -123,7 +125,7 @@ public class RunningRecordService {
     @Transactional
     public void restoreRunningRecord(Long recordId, Long userId) {
         RunningRecord record = runningRecordRepository.findByIdAndUserIdAndIsDeletedTrue(recordId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("복구할 수 있는 기록이 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND, "복구할 수 있는 기록이 없습니다."));
 
         record.restore();
         log.info("러닝 기록 복구 완료: recordId={}", recordId);
@@ -132,7 +134,7 @@ public class RunningRecordService {
     @Transactional
     public void permanentlyDeleteRecord(Long recordId, Long userId) {
         RunningRecord record = runningRecordRepository.findByIdAndUserIdAndIsDeletedTrue(recordId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("영구 삭제할 수 있는 기록이 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND, "영구 삭제할 수 있는 기록이 없습니다."));
 
         if (record.getImageUrl() != null) {
             try {
@@ -175,9 +177,11 @@ public class RunningRecordService {
                 totalDistance += haversine(lat1, lon1, lat2, lon2);
             }
             return totalDistance;
+        } catch (BusinessException e) {
+            throw e;
         } catch (Exception e) {
             log.error("GeoJSON 파싱 오류: {}", e.getMessage());
-            throw new RuntimeException("경로 정보를 처리하는 중 오류가 발생했습니다", e);
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "경로 정보를 처리하는 중 오류가 발생했습니다");
         }
     }
 

--- a/src/main/java/runrush/be/s3/service/ImageUploadService.java
+++ b/src/main/java/runrush/be/s3/service/ImageUploadService.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import runrush.be.common.exception.BusinessException;
+import runrush.be.common.exception.ErrorCode;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
@@ -56,10 +58,10 @@ public class ImageUploadService {
 
         } catch (IOException e) {
             log.error("파일 읽기 실패", e);
-            throw new RuntimeException("파일 업로드 중 오류가 발생했습니다.", e);
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED, "파일 업로드 중 오류가 발생했습니다.");
         } catch (S3Exception e) {
             log.error("S3 업로드 실패", e);
-            throw new RuntimeException("S3 업로드에 실패했습니다: " + e.awsErrorDetails().errorMessage(), e);
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED, "S3 업로드에 실패했습니다: " + e.awsErrorDetails().errorMessage());
         }
 
     }
@@ -80,23 +82,25 @@ public class ImageUploadService {
             s3Client.deleteObject(request);
             log.info("S3 이미지 삭제 성공: {}", imageUrl);
 
-        } catch (IllegalArgumentException e) {
-            log.error("잘못된 이미지 URL: {}", imageUrl, e);
+        } catch (BusinessException e) {
+            throw e;
         } catch (S3Exception e) {
             log.error("S3 이미지 삭제 실패: {}", imageUrl, e);
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED, "이미지 삭제에 실패했습니다.");
         } catch (Exception e) {
             log.error("예상치 못한 이미지 삭제 오류: {}", imageUrl, e);
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "이미지 삭제 중 예상치 못한 오류가 발생했습니다.");
         }
     }
 
     private void validateFile(MultipartFile file) {
         if (file == null || file.isEmpty()) {
-            throw new IllegalArgumentException("파일이 존재하지 않습니다.");
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "파일이 존재하지 않습니다.");
         }
 
         String fileName = file.getOriginalFilename();
         if (fileName == null || !fileName.contains(".") || !hasValidExtension(fileName)) {
-            throw new IllegalArgumentException("지원하지 않는 파일 형식입니다. (jpg, jpeg, png, gif)");
+            throw new BusinessException(ErrorCode.INVALID_FILE_FORMAT, "지원하지 않는 파일 형식입니다. (jpg, jpeg, png, gif)");
         }
     }
 
@@ -121,13 +125,15 @@ public class ImageUploadService {
             String path = url.getPath();
 
             if (path == null || path.isEmpty()) {
-                throw new IllegalArgumentException("URL 경로가 없습니다.");
+                throw new BusinessException(ErrorCode.INVALID_REQUEST, "URL 경로가 없습니다.");
             }
 
             return path.startsWith("/") ? path.substring(1) : path;
 
+        } catch (BusinessException e) {
+            throw e;
         } catch (Exception e) {
-            throw new IllegalArgumentException("잘못된 이미지 URL 형식입니다: " + imageUrl, e);
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "잘못된 이미지 URL 형식입니다: " + imageUrl);
         }
     }
 }

--- a/src/main/java/runrush/be/stats/controller/RunningStatsController.java
+++ b/src/main/java/runrush/be/stats/controller/RunningStatsController.java
@@ -31,12 +31,8 @@ public class RunningStatsController {
                                                       @RequestParam(required = false) Integer year,
                                                       @RequestParam(required = false) Integer month,
                                                       @RequestParam(required = false) Integer monthOffset) {
-        try {
-            MonthlyStats stats = runningStatsService.getMonthlyStats(user.getId(), year, month, monthOffset);
-            return ResponseEntity.ok(stats);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        MonthlyStats stats = runningStatsService.getMonthlyStats(user.getId(), year, month, monthOffset);
+        return ResponseEntity.ok(stats);
     }
 
     @GetMapping("/personal-best")

--- a/src/main/java/runrush/be/stats/service/RunningStatsService.java
+++ b/src/main/java/runrush/be/stats/service/RunningStatsService.java
@@ -3,6 +3,8 @@ package runrush.be.stats.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import runrush.be.common.exception.BusinessException;
+import runrush.be.common.exception.ErrorCode;
 import runrush.be.runningrecord.domain.RunningRecord;
 import runrush.be.runningrecord.repository.RunningRecordRepository;
 import runrush.be.stats.dto.MonthlyStats;
@@ -59,7 +61,7 @@ public class RunningStatsService {
 
         if (month != null && year != null) {
             if (month < 1 || month > 12) {
-                throw new IllegalArgumentException("월은 1-12 사이의 값이어야 합니다. 입력값: " + month);
+                throw new BusinessException(ErrorCode.INVALID_REQUEST, "월은 1-12 사이의 값이어야 합니다. 입력값: " + month);
             }
             date = LocalDate.of(year, month, 1);
         } else {

--- a/src/main/java/runrush/be/user/controller/UserController.java
+++ b/src/main/java/runrush/be/user/controller/UserController.java
@@ -5,6 +5,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import runrush.be.auth.model.UserPrincipal;
+import runrush.be.common.exception.BusinessException;
+import runrush.be.common.exception.ErrorCode;
 import runrush.be.user.domain.User;
 import runrush.be.user.dto.UserInfoResponse;
 import runrush.be.user.dto.UserUpdateRequest;
@@ -21,7 +23,7 @@ public class UserController {
     @GetMapping
     public ResponseEntity<UserInfoResponse> getUserInfo(@AuthenticationPrincipal UserPrincipal user) {
         if (user == null) {
-            return ResponseEntity.status(401).build();
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증이 필요합니다.");
         }
 
         User userByEmail = userService.findUserById(user.getId());

--- a/src/main/java/runrush/be/user/service/UserService.java
+++ b/src/main/java/runrush/be/user/service/UserService.java
@@ -3,6 +3,8 @@ package runrush.be.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import runrush.be.common.exception.BusinessException;
+import runrush.be.common.exception.ErrorCode;
 import runrush.be.user.domain.User;
 import runrush.be.user.dto.UserUpdateRequest;
 import runrush.be.user.repository.UserRepository;
@@ -15,13 +17,13 @@ public class UserService {
     @Transactional(readOnly = true)
     public User findUserByEmail(String email) {
         return userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
     @Transactional(readOnly = true)
     public User findUserById(Long id) {
         return userRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. ID=" + id));
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
     @Transactional(readOnly = true)
@@ -35,7 +37,7 @@ public class UserService {
 
         if (request.nickname() != null && !user.getNickname().equals(request.nickname())) {
             if (userRepository.existsByNickname(request.nickname())) {
-                throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+                throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS, "이미 사용 중인 닉네임입니다.");
             }
             user.updateNickname(request.nickname());
         }


### PR DESCRIPTION
### ✨ 작업 내용
- 도메인별 에러 코드를 정의하는 `ErrorCode` enum 클래스 추가
- 공통 비즈니스 예외 처리를 위한 `BusinessException` 구현
- 클라이언트에게 명확한 오류 정보를 제공하기 위한 `ErrorResponse` DTO 작성
- `GlobalExceptionHandler`를 통해 전역 예외 처리 일관화
- JWT 관련 예외 처리 로직 강화 및 클레임에 `token type` 정보 추가
- JWT 인증 필터에 JSON 기반 에러 응답 적용
- 기존 RuntimeException 기반 예외 처리 → `BusinessException`으로 일원화
- try-catch 제거 및 글로벌 핸들러를 통한 간결한 처리 구조로 개선
- `pathGeoJson` 필드를 `TEXT` → `LONGTEXT`로 확장하여 대용량 경로 저장 가능
- `RecommendedCourseResponse`에 `userId` 필드 추가로 사용자 식별 가능
- CORS 설정에 `OPTIONS`, `PATCH` 메서드 허용 추가로 프론트 요청 유연성 확보

### 🎯 관련 이슈
- #41 
