### PR TITLE
추천 코스 예외 처리 개선 및 위치 기반 친구 조회 기능 추가

### DIFF
--- a/src/main/java/runrush/be/common/exception/ErrorCode.java
+++ b/src/main/java/runrush/be/common/exception/ErrorCode.java
@@ -45,6 +45,11 @@ public enum ErrorCode {
     POST_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "P004", "게시글 내용은 필수입니다."),
     POST_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "P005", "게시글 제목이 너무 깁니다."),
 
+    // ===== 추천 코스 관련 에러 (RC: Recommended Course) =====
+    RECOMMENDED_COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "RC001", "추천 코스를 찾을 수 없습니다."),
+    RECOMMENDED_COURSE_ALREADY_EXISTS(HttpStatus.CONFLICT, "RC002", "이미 추천된 기록입니다."),
+    RECOMMENDED_COURSE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "RC003", "추천 코스에 접근할 권한이 없습니다."),
+
     // ===== 댓글 관련 에러 (CM: Comment) =====
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM001", "댓글을 찾을 수 없습니다."),
     COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "CM002", "댓글에 접근할 권한이 없습니다."),

--- a/src/main/java/runrush/be/location/controller/UserLocationController.java
+++ b/src/main/java/runrush/be/location/controller/UserLocationController.java
@@ -8,7 +8,10 @@ import runrush.be.auth.model.UserPrincipal;
 import runrush.be.location.dto.LocationSharingRequest;
 import runrush.be.location.dto.LocationSharingResponse;
 import runrush.be.location.dto.LocationUpdateRequest;
+import runrush.be.location.dto.NearbyFriendResponse;
 import runrush.be.location.service.UserLocationService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/location")
@@ -35,5 +38,14 @@ public class UserLocationController {
     public ResponseEntity<LocationSharingResponse> getLocationSharingStatus(@AuthenticationPrincipal UserPrincipal user) {
         LocationSharingResponse response = userLocationService.getLocationSharingStatus(user.getId());
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/nearby")
+    public ResponseEntity<List<NearbyFriendResponse>> getNearbyFriends(
+            @AuthenticationPrincipal UserPrincipal user,
+            @RequestParam(defaultValue = "0.5") Double radius) {
+
+        List<NearbyFriendResponse> nearbyFriends = userLocationService.getNearbyFriends(user.getId(), radius);
+        return ResponseEntity.ok(nearbyFriends);
     }
 }

--- a/src/main/java/runrush/be/location/service/UserLocationService.java
+++ b/src/main/java/runrush/be/location/service/UserLocationService.java
@@ -75,13 +75,23 @@ public class UserLocationService {
 
     @Transactional(readOnly = true)
     public List<NearbyFriendResponse> getNearbyFriends(Long userId, Double radiusKm) {
-        UserLocation userLocation = userLocationRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.LOCATION_NOT_FOUND, "사용자의 위치 정보가 없습니다. 먼저 위치를 업데이트해주세요."));
+        Optional<UserLocation> userLocationOpt = userLocationRepository.findById(userId);
+        if (userLocationOpt.isEmpty()) {
+            log.debug("사용자 {} 위치 정보 없음, 빈 친구 목록 반환", userId);
+            return List.of();
+        }
+
+        UserLocation userLocation = userLocationOpt.get();
 
         LocalDateTime cutoffTime = LocalDateTime.now().minusMinutes(10);
         List<UserLocation> friendLocations = userLocationRepository.findFriendsWithActiveLocation(userId, cutoffTime);
 
         log.debug("사용자 {} 주변 친구 조회: 활성 친구 {}명, 반경 {}km", userId, friendLocations.size(), radiusKm);
+
+        if (friendLocations.isEmpty()) {
+            log.debug("사용자 {} 주변에 활성 친구 없음", userId);
+            return List.of();
+        }
 
         return friendLocations.stream()
                 .map(location -> {

--- a/src/main/java/runrush/be/recommendedCourse/controller/RecommendedCourseController.java
+++ b/src/main/java/runrush/be/recommendedCourse/controller/RecommendedCourseController.java
@@ -21,10 +21,10 @@ import java.util.List;
 public class RecommendedCourseController {
     private final RecommendedCourseService recommendedCourseService;
 
-    @PostMapping("/{courseId}")
-    public ResponseEntity<Void> createCourse(@PathVariable Long courseId,
+    @PostMapping("/{recordId}")
+    public ResponseEntity<Void> createCourse(@PathVariable Long recordId,
                                              @AuthenticationPrincipal UserPrincipal user) {
-        recommendedCourseService.createRecommendedCourse(courseId, user.getId(), user.getName());
+        recommendedCourseService.createRecommendedCourse(recordId, user.getId(), user.getName());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/runrush/be/recommendedCourse/service/RecommendedCourseService.java
+++ b/src/main/java/runrush/be/recommendedCourse/service/RecommendedCourseService.java
@@ -32,7 +32,7 @@ public class RecommendedCourseService {
         RunningRecord runningRecord = runningRecordService.validateRunningRecord(recordId, userId);
 
         if (recommendedCourseRepository.existsBySourceRecordId(recordId)) {
-            throw new BusinessException(ErrorCode.ALREADY_FRIENDS, "이미 추천된 기록입니다.");
+            throw new BusinessException(ErrorCode.RECOMMENDED_COURSE_ALREADY_EXISTS, "이미 추천된 기록입니다.");
         }
 
         String title = name + "님의 추천 코스 #" + recordId;


### PR DESCRIPTION
### ✨ 작업 내용
- 추천 코스 생성 시 중복 예외 코드(`RECOMMENDED_COURSE_ALREADY_EXISTS`)를 명확히 정의하여 클라이언트에서 예외 상황을 쉽게 처리할 수 있도록 개선했습니다.
- 추천 코스 도메인 전용 예외 코드(`RECOMMENDED_COURSE_*`)를 추가하여 예외의 의도를 명확히 구분할 수 있도록 구성했습니다.
- 추천 코스 생성 API의 경로 파라미터명을 `recordId`로 명확히 변경하여 가독성과 API 명세의 일관성을 개선했습니다.
- 위치 정보가 없거나 반경 내 위치 공유 중인 친구가 없을 경우에도 예외를 발생시키지 않고 **빈 리스트**를 반환하도록 처리하여 사용자 경험을 개선했습니다.
- `/location/nearby` GET API를 통해 반경 내 위치 공유 중인 친구들을 조회할 수 있는 기능을 구현했습니다.  
  - 기본 반경은 0.5km이며, `radius` 쿼리 파라미터로 조정 가능  
  - 최근 10분 이내에 위치가 업데이트되었고, 위치 공유가 활성화된 친구만 조회됨  

### 🎯 관련 이슈
- #45 