### PR TITLE
위치 공유 로직 및 러닝 기록 응답 개선, S3 업로드 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,5 +224,6 @@ application.properties
 .env
 application.yml
 
+CLAUDE.md
 
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,windows,macos,visualstudiocode,intellij+all

--- a/src/main/java/runrush/be/location/domain/UserLocation.java
+++ b/src/main/java/runrush/be/location/domain/UserLocation.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import runrush.be.common.util.GeoUtils;
 import runrush.be.user.domain.User;
 
@@ -12,14 +14,15 @@ import java.time.LocalDateTime;
 @Getter
 @Entity
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "user_location")
 public class UserLocation {
     @Id
-    private Long userId;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @MapsId
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", unique = true, nullable = false)
     private User user;
 
     private Double latitude;
@@ -29,28 +32,25 @@ public class UserLocation {
     @Column(name = "is_sharing")
     private Boolean isSharing;
 
+    @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     @Builder
     public UserLocation(User user, Double latitude, Double longitude, Boolean isSharing) {
         this.user = user;
-        this.userId = user.getId();
         this.latitude = latitude;
         this.longitude = longitude;
         this.isSharing = isSharing != null ? isSharing : true;
-        this.updatedAt = LocalDateTime.now();
     }
 
     public void updateLocation(Double latitude, Double longitude) {
         this.latitude = latitude;
         this.longitude = longitude;
-        this.updatedAt = LocalDateTime.now();
     }
 
     public void toggleSharing(Boolean isSharing) {
         this.isSharing = isSharing;
-        this.updatedAt = LocalDateTime.now();
     }
 
     public double calculateDistance(Double targetLat, Double targetLng) {

--- a/src/main/java/runrush/be/location/repository/UserLocationRepository.java
+++ b/src/main/java/runrush/be/location/repository/UserLocationRepository.java
@@ -8,18 +8,22 @@ import runrush.be.location.domain.UserLocation;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UserLocationRepository extends JpaRepository<UserLocation, Long> {
+
+    Optional<UserLocation> findByUserId(Long userId);
+
     @Query("SELECT ul FROM UserLocation ul " +
             "JOIN FETCH ul.user u " +
             "WHERE ul.isSharing = true " +
             "AND ul.updatedAt > :cutoffTime " +
-            "AND ul.userId != :userId " +
+            "AND ul.user.id != :userId " +
             "AND EXISTS (" +
             "    SELECT 1 FROM Friends f " +
-            "    WHERE ((f.requester.id = :userId AND f.target.id = ul.userId) " +
-            "           OR (f.requester.id = ul.userId AND f.target.id = :userId)) " +
+            "    WHERE ((f.requester.id = :userId AND f.target.id = ul.user.id) " +
+            "           OR (f.requester.id = ul.user.id AND f.target.id = :userId)) " +
             "    AND f.status = 'ACCEPTED'" +
             ")")
     List<UserLocation> findFriendsWithActiveLocation(@Param("userId") Long userId,

--- a/src/main/java/runrush/be/location/service/UserLocationService.java
+++ b/src/main/java/runrush/be/location/service/UserLocationService.java
@@ -27,7 +27,7 @@ public class UserLocationService {
 
     @Transactional
     public LocationSharingResponse setLocationSharing(Long userId, Boolean isSharing) {
-        Optional<UserLocation> existingLocation = userLocationRepository.findById(userId);
+        Optional<UserLocation> existingLocation = userLocationRepository.findByUserId(userId);
 
         if (existingLocation.isPresent()) {
             UserLocation userLocation = existingLocation.get();
@@ -47,7 +47,7 @@ public class UserLocationService {
 
     @Transactional
     public void updateLocation(Long userId, LocationUpdateRequest request) {
-        Optional<UserLocation> existingLocation = userLocationRepository.findById(userId);
+        Optional<UserLocation> existingLocation = userLocationRepository.findByUserId(userId);
 
         if (existingLocation.isPresent()) {
             UserLocation userLocation = existingLocation.get();
@@ -75,7 +75,7 @@ public class UserLocationService {
 
     @Transactional(readOnly = true)
     public List<NearbyFriendResponse> getNearbyFriends(Long userId, Double radiusKm) {
-        Optional<UserLocation> userLocationOpt = userLocationRepository.findById(userId);
+        Optional<UserLocation> userLocationOpt = userLocationRepository.findByUserId(userId);
         if (userLocationOpt.isEmpty()) {
             log.debug("사용자 {} 위치 정보 없음, 빈 친구 목록 반환", userId);
             return List.of();
@@ -106,7 +106,7 @@ public class UserLocationService {
                             location.getUser().getProfileImage(),
                             location.getLatitude(),
                             location.getLongitude(),
-                            distance
+                            Math.round(distance * 100.0) / 100.0
                     );
                 })
                 .filter(friend -> friend.distance() <= radiusKm)
@@ -117,7 +117,7 @@ public class UserLocationService {
 
     @Transactional(readOnly = true)
     public LocationSharingResponse getLocationSharingStatus(Long userId) {
-        Optional<UserLocation> userLocation = userLocationRepository.findById(userId);
+        Optional<UserLocation> userLocation = userLocationRepository.findByUserId(userId);
 
         if (userLocation.isPresent()) {
             Boolean currentStatus = userLocation.get().getIsSharing();

--- a/src/main/java/runrush/be/recommendedCourse/dto/RecommendedCourseListResponse.java
+++ b/src/main/java/runrush/be/recommendedCourse/dto/RecommendedCourseListResponse.java
@@ -20,7 +20,7 @@ public record RecommendedCourseListResponse(
                 course.getImageUrl(),
                 course.getDescription(),
                 course.getEndLocationName(),
-                course.getTotalDistance(),
+                Math.round(course.getTotalDistance() * 100.0) / 100.0,
                 isBookmarked
         );
     }

--- a/src/main/java/runrush/be/recommendedCourse/dto/RecommendedCourseResponse.java
+++ b/src/main/java/runrush/be/recommendedCourse/dto/RecommendedCourseResponse.java
@@ -31,7 +31,7 @@ public record RecommendedCourseResponse(
                 course.getStartLocationName(),
                 course.getEndLocationName(),
                 GeoJsonUtil.parseGeoJson(course.getPathGeoJson()),
-                course.getTotalDistance(),
+                Math.round(course.getTotalDistance() * 100.0) / 100.0,
                 likeCount,
                 isLiked,
                 isBookmarked

--- a/src/main/java/runrush/be/recommendedCourse/repository/RecommendedCourseRepository.java
+++ b/src/main/java/runrush/be/recommendedCourse/repository/RecommendedCourseRepository.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 @Repository
 public interface RecommendedCourseRepository extends JpaRepository<RecommendedCourse, Long> {
     boolean existsBySourceRecordId(Long sourceRecordId);
+    
+    boolean existsBySourceRecordIdAndIsDeletedFalse(Long sourceRecordId);
 
     @Query("SELECT rc FROM RecommendedCourse rc " +
             "JOIN FETCH rc.user " +

--- a/src/main/java/runrush/be/runningrecord/dto/RunningRecordListResponse.java
+++ b/src/main/java/runrush/be/runningrecord/dto/RunningRecordListResponse.java
@@ -16,9 +16,9 @@ public record RunningRecordListResponse(
     public static RunningRecordListResponse toRecordListResponse(RunningRecord record) {
         return new RunningRecordListResponse(
                 record.getId(),
-                record.getTotalDistance(),
+                Math.round(record.getTotalDistance() * 100.0) / 100.0,
                 record.getTotalTime(),
-                record.getPace(),
+                Math.round(record.getPace() * 100.0) / 100.0,
                 record.getEndLocationName(),
                 record.getCreatedAt(),
                 RecommendedCourseInfo.from(record.getRecommendedCourse())

--- a/src/main/java/runrush/be/runningrecord/dto/RunningRecordResponse.java
+++ b/src/main/java/runrush/be/runningrecord/dto/RunningRecordResponse.java
@@ -20,14 +20,15 @@ public record RunningRecordResponse(
         String startLocationName,
         String endLocationName,
         JsonNode pathGeoJson,
-        RecommendedCourseInfo recommendedCourse
+        RecommendedCourseInfo recommendedCourse,
+        boolean isRegisteredAsCourse
 ) {
-    public static RunningRecordResponse toRecordResponse(RunningRecord record) {
+    public static RunningRecordResponse toRecordResponse(RunningRecord record, boolean isRegisteredAsCourse) {
         return new RunningRecordResponse(
                 record.getId(),
-                record.getTotalDistance(),
+                Math.round(record.getTotalDistance() * 100.0) / 100.0,
                 record.getTotalTime(),
-                record.getPace(),
+                Math.round(record.getPace() * 100.0) / 100.0,
                 record.getStartedTime(),
                 record.getEndedTime(),
                 record.getStartLatitude(),
@@ -37,7 +38,8 @@ public record RunningRecordResponse(
                 record.getStartLocationName(),
                 record.getEndLocationName(),
                 GeoJsonUtil.parseGeoJson(record.getPathGeoJson()),
-                RecommendedCourseInfo.from(record.getRecommendedCourse())
+                RecommendedCourseInfo.from(record.getRecommendedCourse()),
+                isRegisteredAsCourse
         );
     }
 }

--- a/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
+++ b/src/main/java/runrush/be/runningrecord/service/RunningRecordService.java
@@ -105,7 +105,9 @@ public class RunningRecordService {
             throw new BusinessException(ErrorCode.RUNNING_RECORD_ACCESS_DENIED);
         }
 
-        return RunningRecordResponse.toRecordResponse(runningRecord);
+        boolean isRegisteredAsCourse = recommendedCourseRepository.existsBySourceRecordIdAndIsDeletedFalse(recordId);
+
+        return RunningRecordResponse.toRecordResponse(runningRecord, isRegisteredAsCourse);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/runrush/be/s3/service/ImageUploadService.java
+++ b/src/main/java/runrush/be/s3/service/ImageUploadService.java
@@ -42,7 +42,6 @@ public class ImageUploadService {
             PutObjectRequest request = PutObjectRequest.builder()
                     .bucket(bucketName)
                     .key(key)
-                    .acl("public-read")
                     .contentType(file.getContentType())
                     .build();
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: false
     properties:
       hibernate:


### PR DESCRIPTION
### ✨ 작업 내용
- **UserLocation 엔티티 구조 개선**  
  - 기존 `@MapsId` 기반 복합 키 구조 제거  
  - 독립적인 `@Id` 필드(`Long id`) 도입 및 `@OneToOne` 단방향 매핑 변경
  - `@LastModifiedDate`를 활용하여 위치 공유 시 `updatedAt` 자동 갱신 처리 가능하게 변경
- **위치 공유 쿼리 로직 개선**  
  - 친구 중 `isSharing = true`이며 최근 위치 정보가 있는 유저만 필터링하는 쿼리 추가
- **러닝 기록 응답/서비스 개선**  
  - `RunningRecordResponse`에 `isRegisteredAsCourse` 필드 추가 → 추천 코스로 등록 여부 확인 가능
  - `RunningRecordService`에서 추천 코스 등록 여부 판단 후 DTO에 전달
  - 거리/페이스는 소수점 2자리로 반올림 처리
- **S3 이미지 업로드 리팩토링**  
  - `PutObjectRequest`에서 `public-read` ACL 제거 → IAM 정책에 따라 접근 권한 제어 일원화

### 🎯 관련 이슈
- #51 