### PR TITLE
Swagger 설정 및 API 문서화 어노테이션 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 }
 
 tasks.named('test') {

--- a/src/main/java/runrush/be/auth/controller/AuthController.java
+++ b/src/main/java/runrush/be/auth/controller/AuthController.java
@@ -1,5 +1,9 @@
 package runrush.be.auth.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -20,6 +24,7 @@ import runrush.be.common.exception.ErrorCode;
 import java.time.Instant;
 import java.util.Map;
 
+@Tag(name = "Authentication", description = "인증 관리 API")
 @Slf4j
 @RestController
 @RequestMapping("/auth")
@@ -29,10 +34,13 @@ public class AuthController {
     private final AuthService authService;
     private final RefreshTokenService refreshTokenService;
 
+    @Operation(summary = "로그아웃", description = "사용자 로그아웃을 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(
-                                         HttpServletRequest request,
-                                         HttpServletResponse response) {
+    public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
         String accessToken = request.getHeader("Authorization");
 
         authService.logout(accessToken, response);
@@ -40,6 +48,11 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+            @ApiResponse(responseCode = "401", description = "리프레시 토큰 만료 또는 유효하지 않음")
+    })
     @PostMapping("/refresh")
     public ResponseEntity<?> reissue(HttpServletRequest request) {
         String refreshToken = getRefreshTokenFromCookie(request);
@@ -51,6 +64,11 @@ public class AuthController {
         ));
     }
 
+    @Operation(summary = "액세스 토큰 발급", description = "리프레시 토큰을 사용하여 액세스 토큰을 발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "토큰 발급 성공"),
+            @ApiResponse(responseCode = "401", description = "리프레시 토큰 만료 또는 유효하지 않음")
+    })
     @GetMapping("/token")
     public ResponseEntity<?> getAccessToken(HttpServletRequest request) {
         String refreshToken = getRefreshTokenFromCookie(request);
@@ -73,9 +91,9 @@ public class AuthController {
 
     private String getRefreshTokenFromCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
-        if(cookies != null) {
-            for( Cookie cookie : cookies ) {
-                if(cookie.getName().equals("refresh_token")) {
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("refresh_token")) {
                     return cookie.getValue();
                 }
             }

--- a/src/main/java/runrush/be/check/HealthController.java
+++ b/src/main/java/runrush/be/check/HealthController.java
@@ -1,11 +1,20 @@
 package runrush.be.check;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Health Check", description = "서버 상태 확인 API")
 @RestController
 public class HealthController {
+    @Operation(summary = "서버 상태 확인", description = "서버가 정상적으로 동작하는지 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "서버 정상 동작")
+    })
     @GetMapping("/health-check")
     public ResponseEntity<String> healthCheck() {
         return ResponseEntity.ok("OK");

--- a/src/main/java/runrush/be/config/OpenApiConfig.java
+++ b/src/main/java/runrush/be/config/OpenApiConfig.java
@@ -1,0 +1,27 @@
+package runrush.be.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI runrushOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("RunRush API")
+                        .description("러닝 소셜 플랫폼 RunRush의 REST API 문서")
+                        .version("v1.0.0"))
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("JWT 토큰을 사용한 인증")));
+    }
+}

--- a/src/main/java/runrush/be/config/SecurityConfig.java
+++ b/src/main/java/runrush/be/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/health-check").permitAll()
                         .requestMatchers("/oauth2/**", "/login/**", "/auth/token", "/auth/refresh").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/runrush/be/coursebookmark/controller/CourseBookmarkController.java
+++ b/src/main/java/runrush/be/coursebookmark/controller/CourseBookmarkController.java
@@ -1,5 +1,11 @@
 package runrush.be.coursebookmark.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -12,15 +18,23 @@ import runrush.be.coursebookmark.service.CourseBookmarkService;
 
 import java.util.List;
 
+@Tag(name = "Course Bookmark", description = "코스 북마크 관리 API")
 @RestController
 @RequestMapping("/course/bookmark")
 @RequiredArgsConstructor
 public class CourseBookmarkController {
     private final CourseBookmarkService courseBookmarkService;
 
+    @Operation(summary = "코스 북마크 설정", description = "코스의 북마크 상태를 설정하거나 해제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "북마크 설정 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "코스를 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @PatchMapping("/{courseId}")
     public ResponseEntity<BookmarkResponse> setBookmark(
-            @PathVariable Long courseId,
+            @Parameter(description = "코스 ID") @PathVariable Long courseId,
             @AuthenticationPrincipal UserPrincipal user,
             @RequestBody BookmarkRequest request) {
 
@@ -32,15 +46,28 @@ public class CourseBookmarkController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "내 북마크 코스 목록 조회", description = "사용자가 북마크한 코스 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "북마크 코스 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/my")
     public ResponseEntity<List<BookmarkedCourseListResponse>> getMyBookmarkedCourses(@AuthenticationPrincipal UserPrincipal user) {
         List<BookmarkedCourseListResponse> bookmarkedCourses = courseBookmarkService.getBookmarkedCourses(user.getId());
         return ResponseEntity.ok(bookmarkedCourses);
     }
 
+    @Operation(summary = "코스 북마크 상태 조회", description = "특정 코스의 북마크 상태를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "북마크 상태 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "코스를 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/status/{courseId}")
     public ResponseEntity<BookmarkResponse> getBookmarkStatus(
-            @PathVariable Long courseId,
+            @Parameter(description = "코스 ID") @PathVariable Long courseId,
             @AuthenticationPrincipal UserPrincipal user) {
 
         BookmarkResponse response = courseBookmarkService.getBookmarkStatus(user.getId(), courseId);

--- a/src/main/java/runrush/be/courselike/controller/CourseLikeController.java
+++ b/src/main/java/runrush/be/courselike/controller/CourseLikeController.java
@@ -1,5 +1,11 @@
 package runrush.be.courselike.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -10,14 +16,22 @@ import org.springframework.web.bind.annotation.RestController;
 import runrush.be.auth.model.UserPrincipal;
 import runrush.be.courselike.service.CourseLikeService;
 
+@Tag(name = "Course Like", description = "코스 좋아요 관리 API")
 @RestController
 @RequestMapping("/like")
 @RequiredArgsConstructor
 public class CourseLikeController {
     private final CourseLikeService courseLikeService;
 
+    @Operation(summary = "코스 좋아요 토글", description = "코스의 좋아요 상태를 토글합니다. 좋아요가 설정되어 있으면 취소하고, 그렇지 않으면 설정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "좋아요 토글 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "코스를 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/{courseId}")
-    public ResponseEntity<Void> toggleLike(@PathVariable Long courseId,
+    public ResponseEntity<Void> toggleLike(@Parameter(description = "코스 ID") @PathVariable Long courseId,
                                            @AuthenticationPrincipal UserPrincipal user) {
         courseLikeService.likeToggle(user.getId(), courseId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/runrush/be/friends/controller/FriendsController.java
+++ b/src/main/java/runrush/be/friends/controller/FriendsController.java
@@ -1,5 +1,11 @@
 package runrush.be.friends.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,44 +19,79 @@ import runrush.be.friends.service.FriendsService;
 
 import java.util.List;
 
+@Tag(name = "Friends", description = "친구 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/friends")
 public class FriendsController {
     private final FriendsService friendsService;
 
+    @Operation(summary = "친구 요청 전송", description = "다른 사용자에게 친구 요청을 전송합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "친구 요청 전송 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "409", description = "이미 친구이거나 요청이 존재함")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/request")
     public ResponseEntity<Void> sendFriendRequest(
             @AuthenticationPrincipal UserPrincipal user,
-            @RequestParam Long targetId) {
+            @Parameter(description = "친구 요청 대상 사용자 ID") @RequestParam Long targetId) {
         friendsService.sendFriendRequest(user.getId(), targetId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @Operation(summary = "친구 요청 수락", description = "받은 친구 요청을 수락합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "친구 요청 수락 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "친구 요청을 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/request/accept/{requesterId}")
     public ResponseEntity<Void> acceptFriendRequest(
             @AuthenticationPrincipal UserPrincipal user,
-            @PathVariable Long requesterId) {
+            @Parameter(description = "친구 요청자 ID") @PathVariable Long requesterId) {
         friendsService.acceptFriendRequest(user.getId(), requesterId);
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "친구 요청 거절", description = "받은 친구 요청을 거절합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "친구 요청 거절 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "친구 요청을 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/request/reject/{requesterId}")
     public ResponseEntity<Void> rejectFriendRequest(
             @AuthenticationPrincipal UserPrincipal user,
-            @PathVariable Long requesterId) {
+            @Parameter(description = "친구 요청자 ID") @PathVariable Long requesterId) {
         friendsService.rejectFriendRequest(user.getId(), requesterId);
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "친구 삭제", description = "친구 관계를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "친구 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "친구 관계를 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @DeleteMapping("/{friendId}")
     public ResponseEntity<Void> removeFriend(
             @AuthenticationPrincipal UserPrincipal user,
-            @PathVariable Long friendId) {
+            @Parameter(description = "삭제할 친구 ID") @PathVariable Long friendId) {
         friendsService.removeFriend(user.getId(), friendId);
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "내 친구 목록 조회", description = "내 친구 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "친구 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping
     public ResponseEntity<List<FriendResponse>> getMyFriends(
             @AuthenticationPrincipal UserPrincipal user) {
@@ -58,6 +99,12 @@ public class FriendsController {
         return ResponseEntity.ok(myFriends);
     }
 
+    @Operation(summary = "보낸 친구 요청 목록 조회", description = "내가 보낸 친구 요청 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "보낸 친구 요청 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/request/sent")
     public ResponseEntity<List<SentFriendRequestResponse>> getSentMyRequests(
             @AuthenticationPrincipal UserPrincipal user) {
@@ -65,6 +112,12 @@ public class FriendsController {
         return ResponseEntity.ok(sentFriendRequest);
     }
 
+    @Operation(summary = "받은 친구 요청 목록 조회", description = "내가 받은 친구 요청 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "받은 친구 요청 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/request/received")
     public ResponseEntity<List<ReceivedFriendRequestResponse>> getReceivedMyRequests(
             @AuthenticationPrincipal UserPrincipal user) {

--- a/src/main/java/runrush/be/location/controller/UserLocationController.java
+++ b/src/main/java/runrush/be/location/controller/UserLocationController.java
@@ -1,5 +1,11 @@
 package runrush.be.location.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,12 +19,19 @@ import runrush.be.location.service.UserLocationService;
 
 import java.util.List;
 
+@Tag(name = "User Location", description = "사용자 위치 관리 API")
 @RestController
 @RequestMapping("/location")
 @RequiredArgsConstructor
 public class UserLocationController {
     private final UserLocationService userLocationService;
 
+    @Operation(summary = "위치 업데이트", description = "사용자의 현재 위치를 업데이트합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "위치 업데이트 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @PatchMapping
     public ResponseEntity<Void> updateLocation(@AuthenticationPrincipal UserPrincipal user,
                                                @RequestBody LocationUpdateRequest request) {
@@ -26,6 +39,12 @@ public class UserLocationController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "위치 공유 설정", description = "사용자의 위치 공유 여부를 설정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "위치 공유 설정 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @PatchMapping("/sharing")
     public ResponseEntity<LocationSharingResponse> setLocationSharing(
             @AuthenticationPrincipal UserPrincipal user,
@@ -34,16 +53,28 @@ public class UserLocationController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "위치 공유 상태 조회", description = "사용자의 현재 위치 공유 상태를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "위치 공유 상태 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/sharing")
     public ResponseEntity<LocationSharingResponse> getLocationSharingStatus(@AuthenticationPrincipal UserPrincipal user) {
         LocationSharingResponse response = userLocationService.getLocationSharingStatus(user.getId());
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "근처 친구 조회", description = "지정된 반경 내의 친구 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "근처 친구 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/nearby")
     public ResponseEntity<List<NearbyFriendResponse>> getNearbyFriends(
             @AuthenticationPrincipal UserPrincipal user,
-            @RequestParam(defaultValue = "0.5") Double radius) {
+            @Parameter(description = "검색 반경 (단위: km)") @RequestParam(defaultValue = "0.5") Double radius) {
 
         List<NearbyFriendResponse> nearbyFriends = userLocationService.getNearbyFriends(user.getId(), radius);
         return ResponseEntity.ok(nearbyFriends);

--- a/src/main/java/runrush/be/recommendedCourse/controller/RecommendedCourseController.java
+++ b/src/main/java/runrush/be/recommendedCourse/controller/RecommendedCourseController.java
@@ -1,5 +1,11 @@
 package runrush.be.recommendedCourse.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,50 +21,93 @@ import runrush.be.recommendedCourse.service.RecommendedCourseService;
 
 import java.util.List;
 
+@Tag(name = "Recommended Course", description = "추천 코스 관리 API")
 @RestController
 @RequestMapping("/course")
 @RequiredArgsConstructor
 public class RecommendedCourseController {
     private final RecommendedCourseService recommendedCourseService;
 
+    @Operation(summary = "추천 코스 생성", description = "러닝 기록을 기반으로 추천 코스를 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "추천 코스 생성 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "러닝 기록을 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/{recordId}")
-    public ResponseEntity<Void> createCourse(@PathVariable Long recordId,
+    public ResponseEntity<Void> createCourse(@Parameter(description = "러닝 기록 ID") @PathVariable Long recordId,
                                              @AuthenticationPrincipal UserPrincipal user) {
         recommendedCourseService.createRecommendedCourse(recordId, user.getId(), user.getName());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @Operation(summary = "추천 코스 수정", description = "추천 코스의 제목과 설명을 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "추천 코스 수정 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "추천 코스를 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @PatchMapping("/{courseId}")
-    public ResponseEntity<Void> updateCourse(@PathVariable Long courseId,
+    public ResponseEntity<Void> updateCourse(@Parameter(description = "추천 코스 ID") @PathVariable Long courseId,
                                              @AuthenticationPrincipal UserPrincipal user,
                                              @RequestBody RecommendedCourseUpdateRequest request) {
         recommendedCourseService.updateRecommendedCourse(courseId, user.getId(), request);
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "추천 코스 삭제", description = "추천 코스를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "추천 코스 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "추천 코스를 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @DeleteMapping("/{courseId}")
-    public ResponseEntity<Void> deleteCourse(@PathVariable Long courseId,
+    public ResponseEntity<Void> deleteCourse(@Parameter(description = "추천 코스 ID") @PathVariable Long courseId,
                                              @AuthenticationPrincipal UserPrincipal user) {
         recommendedCourseService.deleteRecommendedCourse(courseId, user.getId());
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "추천 코스 상세 조회", description = "추천 코스의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "추천 코스 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "추천 코스를 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/{courseId}")
-    public ResponseEntity<RecommendedCourseResponse> getCourse(@PathVariable Long courseId,
+    public ResponseEntity<RecommendedCourseResponse> getCourse(@Parameter(description = "추천 코스 ID") @PathVariable Long courseId,
                                                                @AuthenticationPrincipal UserPrincipal user) {
         RecommendedCourseResponse recommendedCourse = recommendedCourseService.getRecommendedCourseDetail(courseId, user.getId());
         return ResponseEntity.ok(recommendedCourse);
     }
 
+    @Operation(summary = "내 추천 코스 목록 조회", description = "현재 사용자가 생성한 추천 코스 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "내 추천 코스 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/my")
     public ResponseEntity<List<RecommendedCourseMyListResponse>> getMyRecommendedCourses(@AuthenticationPrincipal UserPrincipal user) {
         List<RecommendedCourseMyListResponse> myRecommendedCourses = recommendedCourseService.getMyRecommendedCourses(user.getId());
         return ResponseEntity.ok(myRecommendedCourses);
     }
 
+    @Operation(summary = "추천 코스 목록 조회", description = "모든 추천 코스 목록을 정렬 옵션에 따라 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "추천 코스 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping
     public ResponseEntity<List<RecommendedCourseListResponse>> getAllRecommendedCourses(
-            @RequestParam(defaultValue = "LIKE") SortType sortType,
+            @Parameter(description = "정렬 타입 (LIKE: 좋아요순, RECENT: 최신순)") @RequestParam(defaultValue = "LIKE") SortType sortType,
             @AuthenticationPrincipal UserPrincipal user
     ) {
         List<RecommendedCourseListResponse> recommendedCourses = recommendedCourseService.getRecommendedCourses(sortType, user.getId());

--- a/src/main/java/runrush/be/runningrecord/controller/RunningRecordController.java
+++ b/src/main/java/runrush/be/runningrecord/controller/RunningRecordController.java
@@ -1,5 +1,13 @@
 package runrush.be.runningrecord.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,58 +22,103 @@ import runrush.be.runningrecord.service.RunningRecordService;
 
 import java.util.List;
 
+@Tag(name = "Running Record", description = "러닝 기록 관리 API")
 @RestController
 @RequestMapping("/running-record")
 @RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
 public class RunningRecordController {
     private final RunningRecordService runningRecordService;
 
+    @Operation(summary = "러닝 기록 생성", description = "새로운 러닝 기록을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "러닝 기록 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PostMapping
-    public ResponseEntity<Void> createRunningRecord(@AuthenticationPrincipal UserPrincipal user,
-                                                    @RequestPart("image") MultipartFile image,
-                                                    @RequestPart("data") RunningRecordRequest request) {
+    public ResponseEntity<Void> createRunningRecord(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal user,
+            @Parameter(description = "러닝 기록 이미지") @RequestPart("image") MultipartFile image,
+            @Parameter(description = "러닝 기록 데이터") @RequestPart("data") RunningRecordRequest request) {
         runningRecordService.saveRunningRecord(request, user.getId(), image);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @Operation(summary = "러닝 기록 목록 조회", description = "사용자의 러닝 기록 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "러닝 기록 목록 조회 성공",
+            content = @Content(schema = @Schema(implementation = RunningRecordListResponse.class)))
     @GetMapping
-    public ResponseEntity<List<RunningRecordListResponse>> getRunningRecords(@AuthenticationPrincipal UserPrincipal user) {
+    public ResponseEntity<List<RunningRecordListResponse>> getRunningRecords(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal user) {
         List<RunningRecordListResponse> runningRecords = runningRecordService.getRunningRecords(user.getId());
         return ResponseEntity.ok(runningRecords);
     }
 
+    @Operation(summary = "러닝 기록 상세 조회", description = "특정 러닝 기록의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "러닝 기록 상세 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "러닝 기록을 찾을 수 없음")
+    })
     @GetMapping("/{recordId}")
-    public ResponseEntity<RunningRecordResponse> getRunningRecord(@PathVariable Long recordId,
-                                                                  @AuthenticationPrincipal UserPrincipal user) {
+    public ResponseEntity<RunningRecordResponse> getRunningRecord(@Parameter(description = "러닝 기록 ID") @PathVariable Long recordId,
+                                                                  @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal user) {
         RunningRecordResponse runningRecord = runningRecordService.getRunningRecord(recordId, user.getEmail());
         return ResponseEntity.ok(runningRecord);
     }
 
+    @Operation(summary = "러닝 기록 삭제", description = "러닝 기록을 소프트 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "러닝 기록 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "러닝 기록을 찾을 수 없음")
+    })
     @DeleteMapping("/{recordId}")
-    public ResponseEntity<Void> deleteRunningRecord(@PathVariable Long recordId,
-                                                    @AuthenticationPrincipal UserPrincipal user) {
+    public ResponseEntity<Void> deleteRunningRecord(@Parameter(description = "러닝 기록 ID") @PathVariable Long recordId,
+                                                    @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal user) {
         runningRecordService.deleteRunningRecord(recordId, user.getId());
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "삭제된 러닝 기록 목록 조회", description = "소프트 삭제된 러닝 기록 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제된 러닝 기록 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @GetMapping("/deleted")
-    public ResponseEntity<List<RunningRecordListResponse>> getDeletedRecords(@AuthenticationPrincipal UserPrincipal user) {
+    public ResponseEntity<List<RunningRecordListResponse>> getDeletedRecords(@Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal user) {
         List<RunningRecordListResponse> deletedRecord = runningRecordService.getDeletedRecord(user.getId());
         return ResponseEntity.ok(deletedRecord);
     }
 
+    @Operation(summary = "러닝 기록 복구", description = "소프트 삭제된 러닝 기록을 복구합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "러닝 기록 복구 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "러닝 기록을 찾을 수 없음")
+    })
     @PutMapping("/restore/{recordId}")
     public ResponseEntity<Void> restoreRunningRecord(
-            @PathVariable Long recordId,
-            @AuthenticationPrincipal UserPrincipal user) {
+            @Parameter(description = "복구할 러닝 기록 ID") @PathVariable Long recordId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal user) {
         runningRecordService.restoreRunningRecord(recordId, user.getId());
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "러닝 기록 영구 삭제", description = "러닝 기록을 영구적으로 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "러닝 기록 영구 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "러닝 기록을 찾을 수 없음")
+    })
     @DeleteMapping("/permanent/{recordId}")
     public ResponseEntity<Void> permanentDeleteRunningRecord(
-            @PathVariable Long recordId,
-            @AuthenticationPrincipal UserPrincipal user) {
+            @Parameter(description = "영구 삭제할 러닝 기록 ID") @PathVariable Long recordId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal user) {
         runningRecordService.permanentlyDeleteRecord(recordId, user.getId());
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/runrush/be/stats/controller/RunningStatsController.java
+++ b/src/main/java/runrush/be/stats/controller/RunningStatsController.java
@@ -1,5 +1,11 @@
 package runrush.be.stats.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -10,48 +16,72 @@ import runrush.be.stats.service.RunningStatsService;
 
 import java.util.List;
 
+@Tag(name = "Running Stats", description = "러닝 통계 API")
 @RestController
 @RequestMapping("/stats")
 @RequiredArgsConstructor
 public class RunningStatsController {
     private final RunningStatsService runningStatsService;
 
+    @Operation(summary = "주간 통계 조회", description = "사용자의 주간 러닝 통계를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "주간 통계 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/weekly")
     public ResponseEntity<WeeklyStatsResponse> getWeeklyStats(@AuthenticationPrincipal UserPrincipal user,
-                                                              @RequestParam(required = false, defaultValue = "0") int weekOffset) {
+                                                              @Parameter(description = "주 오프셋 (0: 이번주, -1: 지난주)") @RequestParam(required = false, defaultValue = "0") int weekOffset) {
         WeeklyStatsResponse stats = runningStatsService.getWeeklyStats(user.getId(), weekOffset);
         return ResponseEntity.ok(stats);
     }
 
+    @Operation(summary = "월간 통계 조회", description = "사용자의 월간 러닝 통계를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "월간 통계 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/monthly")
     public ResponseEntity<MonthlyStatsResponse> getMonthStats(@AuthenticationPrincipal UserPrincipal user,
-                                                              @RequestParam(required = false) Integer year,
-                                                              @RequestParam(required = false) Integer month,
-                                                              @RequestParam(required = false) Integer monthOffset) {
+                                                              @Parameter(description = "연도") @RequestParam(required = false) Integer year,
+                                                              @Parameter(description = "월") @RequestParam(required = false) Integer month,
+                                                              @Parameter(description = "월 오프셋") @RequestParam(required = false) Integer monthOffset) {
         MonthlyStatsResponse stats = runningStatsService.getMonthlyStats(user.getId(), year, month, monthOffset);
         return ResponseEntity.ok(stats);
     }
 
+    @Operation(summary = "개인 베스트 기록 조회", description = "사용자의 개인 베스트 러닝 기록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "개인 베스트 기록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/personal-best")
     public ResponseEntity<PersonalBestStatsResponse> getPersonalBestStats(@AuthenticationPrincipal UserPrincipal user) {
         PersonalBestStatsResponse stats = runningStatsService.getPersonalBestStats(user.getId());
         return ResponseEntity.ok(stats);
     }
 
-    /**
-     * 특정 추천 코스의 상세 통계 조회
-     */
+    @Operation(summary = "추천 코스 상세 통계 조회", description = "특정 추천 코스의 상세 통계를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "추천 코스 상세 통계 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "추천 코스를 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/recommended-course/{courseId}")
     public ResponseEntity<RecommendedCourseDetailStatsResponse> getRecommendedCourseDetailStats(
-            @PathVariable Long courseId,
+            @Parameter(description = "추천 코스 ID") @PathVariable Long courseId,
             @AuthenticationPrincipal UserPrincipal user) {
         RecommendedCourseDetailStatsResponse stats = runningStatsService.getRecommendedCourseDetailStats(courseId, user.getId());
         return ResponseEntity.ok(stats);
     }
 
-    /**
-     * 인기 추천 코스 TOP 10 조회
-     */
+    @Operation(summary = "인기 추천 코스 TOP 10 조회", description = "가장 인기 있는 추천 코스 TOP 10을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "인기 추천 코스 조회 성공")
+    })
     @GetMapping("/popular-courses")
     public ResponseEntity<List<PopularRecommendedCourseResponse>> getPopularRecommendedCourses() {
         List<PopularRecommendedCourseResponse> stats = runningStatsService.getPopularRecommendedCourses();

--- a/src/main/java/runrush/be/user/controller/UserController.java
+++ b/src/main/java/runrush/be/user/controller/UserController.java
@@ -1,5 +1,11 @@
 package runrush.be.user.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,12 +20,19 @@ import runrush.be.user.service.UserService;
 
 import java.util.Map;
 
+@Tag(name = "User", description = "사용자 관리 API")
 @RestController
 @RequestMapping("/user")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
 
+    @Operation(summary = "사용자 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping
     public ResponseEntity<UserInfoResponse> getUserInfo(@AuthenticationPrincipal UserPrincipal user) {
         if (user == null) {
@@ -31,8 +44,13 @@ public class UserController {
         return ResponseEntity.ok(userInfoResponse);
     }
 
+    @Operation(summary = "닉네임 중복 확인", description = "입력한 닉네임의 사용 가능 여부를 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용 가능한 닉네임"),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 닉네임")
+    })
     @GetMapping("/check-nickname")
-    public ResponseEntity<Map<String, Object>> checkNickname(@RequestParam String nickname) {
+    public ResponseEntity<Map<String, Object>> checkNickname(@Parameter(description = "확인할 닉네임") @RequestParam String nickname) {
         boolean isAvailable = userService.isNicknameAvailable(nickname);
 
         if (isAvailable) {
@@ -48,6 +66,13 @@ public class UserController {
         }
     }
 
+    @Operation(summary = "사용자 프로필 수정", description = "사용자의 프로필 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프로필 수정 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 닉네임")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @PatchMapping("/update")
     public ResponseEntity<Void> updateProfile(@AuthenticationPrincipal UserPrincipal user,
                                               @RequestBody UserUpdateRequest request) {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -56,6 +56,14 @@ app:
   oauth2:
     redirect-uri: ${OAUTH2_REDIRECT_URI}
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    enabled: true
+  show-actuator: false
+
 cloud:
   aws:
     credentials:


### PR DESCRIPTION
## ✨ 작업 내용
- `springdoc-openapi` 라이브러리 의존성 추가
- Swagger 설정 클래스(`OpenApiConfig`)를 통해 API 문서 메타 정보 및 JWT 인증 설정 적용
- 각 Controller에 Swagger 문서화 어노테이션(`@Tag`, `@Operation`, `@ApiResponses`) 추가
- Swagger UI 및 OpenAPI 문서 경로(`/swagger-ui.html`, `/swagger-ui/**`, `/v3/api-docs/**`)를 인증 예외로 등록하여 로그인 없이 접근 가능하도록 설정

## 🎯 관련 이슈
- #53 
