### PR TITLE
Prometheus + Grafana 모니터링 스택 구축 및 설정 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,6 +223,7 @@ gradle-app.setting
 application.properties
 .env
 application.yml
+docker-compose-local.yml
 
 CLAUDE.md
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-alpine
+FROM eclipse-temurin:17-jdk
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+	/* Monitoring */
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
 	implementation 'software.amazon.awssdk:s3:2.25.12'
 
 	/* jwt */

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: 'spring-boot-app'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'app:8080' ]

--- a/src/main/java/runrush/be/config/SecurityConfig.java
+++ b/src/main/java/runrush/be/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/health-check").permitAll()
                         .requestMatchers("/oauth2/**", "/login/**", "/auth/token", "/auth/refresh").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()


### PR DESCRIPTION
## ✨ 작업 내용

- **Prometheus 메트릭 수집**  
  Spring Boot 애플리케이션의 `/actuator/prometheus` 엔드포인트를 통해 JVM, HTTP, 데이터베이스 등의 메트릭을 5초 간격으로 수집

- **Grafana 시각화**  
  수집된 메트릭을 Grafana 대시보드를 통해 실시간으로 모니터링 가능  
  URL: http://localhost:3001  
  계정: admin / admin

- **보안 설정**  
  Spring Security에서 모니터링 엔드포인트에 대한 인증을 우회하여 Prometheus가 원활히 메트릭을 수집할 수 있도록 구성

- **로컬 개발 환경 구성**  
  Docker Compose를 통해 MySQL, Spring Boot App, Prometheus, Grafana를 통합 관리

---

## 🎯 관련 이슈

- #62 